### PR TITLE
Revert "Bump pre-commit from 2.17.0 to 2.19.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "test": [
             "pytest==7.0.1",
             "xkcdpass==1.19.3",
-            "pre-commit==2.19.0",  # not really for tests, but for development
+            "pre-commit==2.17.0",  # not really for tests, but for development
             "coverage==6.2",
             "pytest-cov==3.0.0",
             "deepdiff==5.7.0",


### PR DESCRIPTION
Reverts gitlabform/gitlabform#377

...because this pre-commit version ALSO requires > py3.6. :(