### PR TITLE
Fix Integrations documentation

### DIFF
--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -11,7 +11,7 @@ Example:
 ```yaml
 projects_and_groups:
   group_1/project_1:
-    services:
+    integrations:
       slack:
         delete: true
       drone-ci:


### PR DESCRIPTION
The documentation was using `services` as key which is outdated. This was recently replaced with `integrations`. The tests were already updated in a prior commit but the documentation was forgotten. See here: https://github.com/gitlabform/gitlabform/commit/5bae26f09f1dca5307530db51376f90130d8d42e