### PR TITLE
Friendlier key not found exception msg

### DIFF
--- a/gitlabform/configuration/core.py
+++ b/gitlabform/configuration/core.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import os
+import logging
 import textwrap
 from abc import ABC
 from copy import deepcopy
@@ -154,7 +155,7 @@ class ConfigurationCore(ABC):
             if default is not None:
                 to_return = default
             else:
-                raise KeyNotFoundException
+                raise KeyNotFoundException(path) from None
 
         return to_return
 
@@ -318,4 +319,13 @@ class ConfigInvalidException(Exception):
 
 
 class KeyNotFoundException(Exception):
-    pass
+    __slots__ = "key"
+
+    def __init__(self, key: str):
+        if logging.getLogger().getEffectiveLevel() <= logging.DEBUG:
+            self.key = key
+        else:
+            fatal(
+                f"Unable to find the key: {key.replace('|', '.')}\n",
+                exit_code=EXIT_INVALID_INPUT,
+            )


### PR DESCRIPTION
Hi, I'm getting acquainted with gitlabform, just trying to run it gives a kind of intimidating error msg:

> $ python gitlabform/run.py -c ...
🏗  GitLabForm version: 3.2.0 = the latest stable 😊
Reading config from file: ../../gitlab-config/config.yml
Traceback (most recent call last):
  File "/Users/rzanella/oss/gitlabform/gitlabform/configuration/core.py", line 138, in get
    current = current[token]
  File "/Users/rzanella/oss/gitlabform/venv/lib/python3.9/site-packages/ruamel.yaml-0.17.21-py3.9.egg/ruamel/yaml/comments.py", line 927, in __getitem__
    return ordereddict.__getitem__(self, key)
KeyError: 'token'
>
>During handling of the above exception, another exception occurred:
>
>Traceback (most recent call last):
  File "/Users/rzanella/oss/gitlabform/gitlabform/run.py", line 9, in <module>
    run()
  File "/Users/rzanella/oss/gitlabform/gitlabform/run.py", line 5, in run
    GitLabForm().run()
  File "/Users/rzanella/oss/gitlabform/gitlabform/core.py", line 97, in __init__
    self.gitlab, self.configuration = self.initialize_configuration_and_gitlab()
  File "/Users/rzanella/oss/gitlabform/gitlabform/core.py", line 306, in initialize_configuration_and_gitlab
    gitlab = GitLab(config_path=self.config)
  File "/Users/rzanella/oss/gitlabform/gitlabform/gitlab/core.py", line 27, in __init__
    self.token = self.configuration.get("gitlab|token", os.getenv("GITLAB_TOKEN"))
  File "/Users/rzanella/oss/gitlabform/gitlabform/configuration/core.py", line 143, in get
    raise KeyNotFoundException
gitlabform.configuration.core.KeyNotFoundException

This PR tries to make it a bit more user-friendly:

>$ python gitlabform/run.py ...
> 🏗  GitLabForm version: 3.2.0 = the latest stable 😊
> Error: Unable to find the key: gitlab.token
