### PR TITLE
Refactor: edit users as members of projects and groups

### DIFF
--- a/gitlabform/gitlab/members.py
+++ b/gitlabform/gitlab/members.py
@@ -21,13 +21,11 @@ class GitLabMembers(GitLabCore):
         username,
         access_level,
         expires_at=None,
-        user_id=None,
     ):
-        if not user_id:
-            user_id = self._get_user_id(username)
-        data = {"user_id": user_id, "expires_at": expires_at}
-        if access_level is not None:
-            data["access_level"] = access_level
+        user_id = self._get_user_id(username)
+        data = {"user_id": user_id, "access_level": access_level}
+        if expires_at:
+            data["expires_at"] = expires_at
 
         return self._make_requests_to_api(
             "projects/%s/members",
@@ -37,17 +35,31 @@ class GitLabMembers(GitLabCore):
             expected_codes=201,
         )
 
-    def remove_member_from_project(
-        self, project_and_group_name, username, user_id=None
-    ):
-        if not user_id:
-            user_id = self._get_user_id(username)
+    def remove_member_from_project(self, project_and_group_name, username):
+        user_id = self._get_user_id(username)
+
         # 404 means that the user is already not a member of the project, so let's accept it for idempotency
         return self._make_requests_to_api(
             "projects/%s/members/%s",
             (project_and_group_name, user_id),
             method="DELETE",
             expected_codes=[204, 404],
+        )
+
+    def edit_member_of_project(
+        self, group_name, username, access_level, expires_at=None
+    ):
+        user_id = self._get_user_id(username)
+        data = {"user_id": user_id, "access_level": access_level}
+        if expires_at:
+            data["expires_at"] = expires_at
+
+        return self._make_requests_to_api(
+            "projects/%s/members/%s",
+            (group_name, user_id),
+            method="PUT",
+            data=data,
+            expected_codes=200,
         )
 
     def get_group_members(self, group_name, with_inherited=False):
@@ -71,14 +83,11 @@ class GitLabMembers(GitLabCore):
 
         return final_members
 
-    def add_member_to_group(
-        self, group_name, username, access_level, expires_at=None, user_id=None
-    ):
-        if not user_id:
-            user_id = self._get_user_id(username)
-        data = {"user_id": user_id, "expires_at": expires_at}
-        if access_level is not None:
-            data["access_level"] = access_level
+    def add_member_to_group(self, group_name, username, access_level, expires_at=None):
+        user_id = self._get_user_id(username)
+        data = {"user_id": user_id, "access_level": access_level}
+        if expires_at:
+            data["expires_at"] = expires_at
 
         return self._make_requests_to_api(
             "groups/%s/members",
@@ -88,13 +97,27 @@ class GitLabMembers(GitLabCore):
             expected_codes=201,
         )
 
-    def remove_member_from_group(self, group_name, username, user_id=None):
-        if not user_id:
-            user_id = self._get_user_id(username)
+    def remove_member_from_group(self, group_name, username):
+        user_id = self._get_user_id(username)
+
         # 404 means that the user is already removed, so let's accept it for idempotency
         return self._make_requests_to_api(
             "groups/%s/members/%s",
             (group_name, user_id),
             method="DELETE",
             expected_codes=[204, 404],
+        )
+
+    def edit_member_of_group(self, group_name, username, access_level, expires_at=None):
+        user_id = self._get_user_id(username)
+        data = {"user_id": user_id, "access_level": access_level}
+        if expires_at:
+            data["expires_at"] = expires_at
+
+        return self._make_requests_to_api(
+            "groups/%s/members/%s",
+            (group_name, user_id),
+            method="PUT",
+            data=data,
+            expected_codes=200,
         )

--- a/gitlabform/processors/group/group_members_processor.py
+++ b/gitlabform/processors/group/group_members_processor.py
@@ -197,13 +197,10 @@ class GroupMembersProcessor(AbstractProcessor):
                             )
                         else:
                             debug(
-                                "Re-adding user '%s' to change their access level or expires at.",
+                                "Editing user '%s' membership to change their access level or expires at.",
                                 user,
                             )
-                            # we will remove the user first and then re-add they,
-                            # to ensure that the user has the expected access level
-                            self.gitlab.remove_member_from_group(group, user)
-                            self.gitlab.add_member_to_group(
+                            self.gitlab.edit_member_of_group(
                                 group, user, access_level_to_set, expires_at_to_set
                             )
 

--- a/gitlabform/processors/project/members_processor.py
+++ b/gitlabform/processors/project/members_processor.py
@@ -109,23 +109,31 @@ class MembersProcessor(AbstractProcessor):
                     else None
                 )
                 # we only add the user if it doesn't have the correct settings
-                if (
-                    user in current_members
-                    and expires_at == current_members[user]["expires_at"]
-                    and access_level == current_members[user]["access_level"]
-                ):
-                    debug("Ignoring user '%s' as it is already a member", user)
-                    debug(
-                        "Current settings for '%s' are: %s"
-                        % (user, current_members[user])
-                    )
+                if user in current_members:
+                    if (
+                        expires_at == current_members[user]["expires_at"]
+                        and access_level == current_members[user]["access_level"]
+                    ):
+                        debug(
+                            "Nothing to change for user '%s' - same config now as to set.",
+                            user,
+                        )
+                        debug(
+                            "Current settings for '%s' are: %s"
+                            % (user, current_members[user])
+                        )
+                    else:
+                        debug(
+                            "Editing user '%s' membership to change their access level or expires at",
+                            user,
+                        )
+                        self.gitlab.edit_member_of_project(
+                            project_and_group, user, access_level, expires_at
+                        )
                 else:
-                    debug("Setting user '%s' as a member", user)
-                    access = access_level
-                    expiry = expires_at
-                    self.gitlab.remove_member_from_project(project_and_group, user)
+                    debug("Adding user '%s' who previously was not a member.", user)
                     self.gitlab.add_member_to_project(
-                        project_and_group, user, access, expiry
+                        project_and_group, user, access_level, expires_at
                     )
 
         if enforce_members:

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -211,11 +211,11 @@ def make_user(
             username,
             get_random_password(),
         )
-        user_obj = User(username, user["id"])
+
         if add_to_project:
-            gitlab.add_member_to_project(
-                group_and_project, None, level.value, user_id=user["id"]
-            )
+            gitlab.add_member_to_project(group_and_project, username, level.value)
+
+        user_obj = User(username, user["id"])
         created_users.append(user_obj)
         return user_obj
 

--- a/tests/acceptance/standard/test_group_members_users.py
+++ b/tests/acceptance/standard/test_group_members_users.py
@@ -214,3 +214,23 @@ class TestGroupMembersUsers:
 
         members_usernames = [member["username"] for member in members]
         assert members_usernames.count(user_to_add) == 1
+
+    def test__root_as_the_sole_owner(self, gitlab, group):
+
+        config = f"""
+            projects_and_groups:
+              {group}/*:
+                group_members:
+                  users:
+                    root:
+                      access_level: {AccessLevel.OWNER.value}
+                  enforce: true
+            """
+
+        run_gitlabform(config, group)
+
+        members = gitlab.get_group_members(group)
+        assert len(members) == 1
+
+        assert members[0]["username"] == "root"
+        assert members[0]["access_level"] == AccessLevel.OWNER.value

--- a/tests/acceptance/standard/test_members_add_group.py
+++ b/tests/acceptance/standard/test_members_add_group.py
@@ -12,10 +12,10 @@ def two_members_in_other_group(gitlab, other_group, make_user):
     outsider_user2 = make_user(add_to_project=False)
 
     gitlab.add_member_to_group(
-        other_group, None, AccessLevel.OWNER.value, user_id=outsider_user1.id
+        other_group, outsider_user1.name, AccessLevel.OWNER.value
     )
     gitlab.add_member_to_group(
-        other_group, None, AccessLevel.DEVELOPER.value, user_id=outsider_user2.id
+        other_group, outsider_user2.name, AccessLevel.DEVELOPER.value
     )
 
     yield [outsider_user1.name, outsider_user2.name]


### PR DESCRIPTION
instead of removing and re-adding them for a cleaner audit log.

Also stop allowing to pass user_id separately from username
- this is unnecessary complexity with little benefit (1 less API call in some rare cases).

Related to #466.