### PR TITLE
[Bug Fix] Fix protected branches current configuration access level fetching

### DIFF
--- a/gitlabform/processors/util/branch_protector.py
+++ b/gitlabform/processors/util/branch_protector.py
@@ -277,7 +277,7 @@ class BranchProtector:
         for array_element in protected_branches_response.get(
             f"{action}_access_levels", []
         ):
-            if array_element.get("access_level"):
+            if array_element.get("access_level") is not None:
                 levels.add(array_element.get("access_level"))
             elif array_element.get("user_id"):
                 user_ids.add(array_element.get("user_id"))

--- a/tests/unit/processors/test_branch_protector.py
+++ b/tests/unit/processors/test_branch_protector.py
@@ -1,0 +1,27 @@
+from gitlabform.processors.util.branch_protector import BranchProtector
+
+
+def test_get_current_permissions_handles_zero_access_level():
+    bp = BranchProtector(None, False)
+    test_protected_branches_response = {
+        "id": 1,
+        "name": "master",
+        "push_access_levels": [
+            {"access_level": 0, "access_level_description": "Push Description"}
+        ],
+        "merge_access_levels": [
+            {"access_level": 40, "access_level_description": "Merge Description"}
+        ],
+        "allow_force_push": False,
+        "code_owner_approval_required": False,
+    }
+
+    push_levels, _, _ = bp.get_current_permissions(
+        test_protected_branches_response, "push"
+    )
+    assert push_levels == [0]
+
+    merge_levels, _, _ = bp.get_current_permissions(
+        test_protected_branches_response, "merge"
+    )
+    assert merge_levels == [40]


### PR DESCRIPTION
The `get_current_permissions` method in `branch_protector.py` does not properly account for returned `access_levels` when they are set to `0`.

This PR just adds a verification that the `access_level` value is present, otherwise the if check becomes `if 0:` when the 0 access level is set, which equates to False, resulting in unnecessary reapplications of branch protection settings.