### PR TITLE
Stop treating usernames as case-sensitive

### DIFF
--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -173,6 +173,10 @@ def delete_pipeline_schedules_from_project(project_and_group):
         gl.delete_pipeline_schedule(project_and_group, schedule["id"])
 
 
+def randomize_case(input: str) -> str:
+    return "".join(random.choice((str.upper, str.lower))(char) for char in input)
+
+
 def run_gitlabform(config, target, include_archived_projects=True):
     # f-strings with """ used as configs have the disadvantage of having indentation in them - let's remove it here
     config = textwrap.dedent(config)

--- a/tests/acceptance/premium/test_branches_users_case_insensitive.py
+++ b/tests/acceptance/premium/test_branches_users_case_insensitive.py
@@ -1,0 +1,57 @@
+import pytest
+
+from gitlabform.gitlab.core import NotFoundException
+from gitlabform.gitlab import AccessLevel
+from tests.acceptance import run_gitlabform, gl, randomize_case
+
+
+class TestBranchesUsersCaseInsensitive:
+    @pytest.mark.skipif(
+        gl.has_no_license(), reason="this test requires a GitLab license (Paid/Trial)"
+    )
+    def test__users_case_insensitive(
+        self,
+        gitlab,
+        group_and_project,
+        branch,
+        make_user,
+    ):
+        first_user = make_user(AccessLevel.DEVELOPER)
+        second_user = make_user(AccessLevel.DEVELOPER)
+        third_user = make_user(AccessLevel.DEVELOPER)
+
+        config_with_more_user_ids = f"""
+        projects_and_groups:
+          {group_and_project}:
+            branches:
+              {branch}:
+                protected: true
+                allowed_to_push:
+                  - access_level: {AccessLevel.MAINTAINER.value} 
+                  - user: {randomize_case(first_user.name)}
+                  - user: {randomize_case(second_user.name)}
+                  - user: {randomize_case(third_user.name)}
+                allowed_to_merge:
+                  - access_level: {AccessLevel.MAINTAINER.value}
+        """
+
+        run_gitlabform(config_with_more_user_ids, group_and_project)
+
+        (
+            push_access_levels,
+            merge_access_levels,
+            push_access_user_ids,
+            merge_access_user_ids,
+            _,
+        ) = gitlab.get_only_branch_access_levels(group_and_project, branch)
+
+        assert push_access_levels == [AccessLevel.MAINTAINER.value]
+        assert merge_access_levels == [AccessLevel.MAINTAINER.value]
+        assert push_access_user_ids == sorted(
+            [
+                first_user.id,
+                second_user.id,
+                third_user.id,
+            ]
+        )
+        assert merge_access_user_ids == []

--- a/tests/acceptance/standard/test_group_members_case_insensitive.py
+++ b/tests/acceptance/standard/test_group_members_case_insensitive.py
@@ -1,0 +1,110 @@
+import pytest
+
+from gitlabform.gitlab import AccessLevel
+from tests.acceptance import (
+    run_gitlabform,
+    randomize_case,
+)
+
+
+@pytest.fixture(scope="function")
+def one_owner_and_two_developers(gitlab, group, users):
+
+    gitlab.add_member_to_group(group, users[0], AccessLevel.OWNER.value)
+    gitlab.add_member_to_group(group, users[1], AccessLevel.DEVELOPER.value)
+    gitlab.add_member_to_group(group, users[2], AccessLevel.DEVELOPER.value)
+    gitlab.remove_member_from_group(group, "root")
+
+    yield group
+
+    # we are running tests with root's token, so every group is created
+    # with a single user - root as owner. we restore the group to
+    # this state here.
+
+    gitlab.add_member_to_group(group, "root", AccessLevel.OWNER.value)
+
+    # we try to remove all users, not just those added above,
+    # on purpose, as more may have been added in the tests
+    for user in users:
+        gitlab.remove_member_from_group(group, user)
+
+
+@pytest.fixture(scope="function")
+def one_owner(gitlab, group, groups, subgroup, users):
+
+    gitlab.add_member_to_group(group, users[0], AccessLevel.OWNER.value)
+    gitlab.remove_member_from_group(group, "root")
+
+    yield group
+
+    # we are running tests with root's token, so every group is created
+    # with a single user - root as owner. we restore the group to
+    # this state here.
+
+    gitlab.add_member_to_group(group, "root", AccessLevel.OWNER.value)
+
+    # we try to remove all users, not just those added above,
+    # on purpose, as more may have been added in the tests
+    for user in users:
+        gitlab.remove_member_from_group(group, user)
+
+    gitlab.remove_share_from_group(group, subgroup)
+    for share_with in groups:
+        gitlab.remove_share_from_group(group, share_with)
+
+
+class TestGroupMembersCaseInsensitive:
+    def test__user_case_insensitive(
+        self, gitlab, group, users, one_owner_and_two_developers
+    ):
+
+        no_of_members_before = len(gitlab.get_group_members(group))
+        user_to_add = f"{users[3]}"
+
+        add_users = f"""
+            projects_and_groups:
+              {group}/*:
+                group_members:
+                  users:
+                    {randomize_case(users[0])}:
+                      access_level: {AccessLevel.OWNER.value}
+                    {randomize_case(users[1])}:
+                      access_level: {AccessLevel.DEVELOPER.value}
+                    {randomize_case(users[2])}:
+                      access_level: {AccessLevel.DEVELOPER.value}
+                    {randomize_case(user_to_add)}: # new user 1
+                      access_level: {AccessLevel.DEVELOPER.value}
+            """
+
+        run_gitlabform(add_users, group)
+
+        members = gitlab.get_group_members(group)
+        assert len(members) == no_of_members_before + 1
+
+        members_usernames = [member["username"] for member in members]
+        assert members_usernames.count(user_to_add) == 1
+
+    def test__group_case_insensitive(self, gitlab, group, users, groups, one_owner):
+        no_of_members_before = len(gitlab.get_group_members(group))
+
+        add_shared_with = f"""
+            projects_and_groups:
+              {group}/*:
+                group_members:
+                  users:
+                    {users[0]}:
+                      access_level: {AccessLevel.OWNER.value}
+                  groups:
+                    {randomize_case(groups[0])}:
+                      group_access: {AccessLevel.DEVELOPER.value}
+                    {randomize_case(groups[1])}:
+                      group_access: {AccessLevel.DEVELOPER.value}
+            """
+
+        run_gitlabform(add_shared_with, group)
+
+        members = gitlab.get_group_members(group)
+        assert len(members) == no_of_members_before, members
+
+        shared_with = gitlab.get_group_shared_with(group)
+        assert len(shared_with) == 2

--- a/tests/acceptance/standard/test_members_case_insensitve.py
+++ b/tests/acceptance/standard/test_members_case_insensitve.py
@@ -1,0 +1,83 @@
+import pytest
+
+from gitlabform.gitlab import AccessLevel
+from tests.acceptance import (
+    run_gitlabform,
+    randomize_case,
+)
+
+
+@pytest.fixture(scope="class")
+def two_members_in_other_group(gitlab, other_group, make_user):
+    outsider_user1 = make_user(add_to_project=False)
+    outsider_user2 = make_user(add_to_project=False)
+
+    gitlab.add_member_to_group(
+        other_group, outsider_user1.name, AccessLevel.OWNER.value
+    )
+    gitlab.add_member_to_group(
+        other_group, outsider_user2.name, AccessLevel.DEVELOPER.value
+    )
+
+    yield [outsider_user1.name, outsider_user2.name]
+
+
+class TestMembersCaseInsensitive:
+    def test__user_case_insensitive(
+        self, gitlab, group_and_project, three_members, outsider_user
+    ):
+
+        member1_name, _, _ = three_members
+
+        change_user_level = f"""
+        projects_and_groups:
+          {group_and_project}:
+            members:
+              users:
+                {randomize_case(member1_name)}: # refer to a user with a different case
+                  access_level: {AccessLevel.MAINTAINER.value}
+        """
+
+        run_gitlabform(change_user_level, group_and_project)
+
+    # this test should be in a separate class than other test files as it changes too
+    # much for a reasonable setup and cleanup using fixtures
+    def test__group_case_insensitive(
+        self,
+        gitlab,
+        group_and_project,
+        three_members,
+        other_group,
+        two_members_in_other_group,
+    ):
+        no_of_members_before = len(gitlab.get_project_members(group_and_project))
+        no_of_members_of_other_group = len(gitlab.get_group_members(other_group))
+
+        no_of_groups_shared_before = len(
+            gitlab.get_shared_with_groups(group_and_project)
+        )
+        assert no_of_groups_shared_before == 0
+
+        add_group = f"""
+        projects_and_groups:
+          {group_and_project}:
+            members:
+              groups:
+                {randomize_case(other_group)}: # refer to a user with a different case
+                  group_access: {AccessLevel.MAINTAINER.value}
+        """
+
+        run_gitlabform(add_group, group_and_project)
+
+        members = gitlab.get_project_members(group_and_project, all=True)
+
+        assert len(members) == no_of_members_before + no_of_members_of_other_group
+
+        for member in members:
+            if member["username"] in two_members_in_other_group:
+                # "group_access" is the *maximum* access level, see
+                # https://docs.gitlab.com/ee/user/project/members/share_project_with_groups.html#maximum-access-level
+                assert member["access_level"] <= AccessLevel.MAINTAINER.value
+
+        no_of_groups_shared = len(gitlab.get_shared_with_groups(group_and_project))
+        assert no_of_groups_shared == 1


### PR DESCRIPTION
...as in fact they are not. (You cannot have 2 users in a GitLab instance for which the username differs only in the case.)

Reported in #466