### PR TITLE
Fix running with ALL when using gitlab.com

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -18,7 +18,7 @@ To apply settings for all groups of projects and projects explicitly defined in 
 gitlabform ALL_DEFINED
 ```
 
-To apply settings for all projects, run:
+To apply settings for all groups and projects that you can modify, run:
 
 ```shell
 gitlabform ALL

--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -562,7 +562,9 @@ class GitLabForm:
         """
 
         if target == "ALL":
-            info(">>> Getting ALL groups and projects that I can modify...")
+            info(
+                ">>> Getting ALL groups and projects that I have permission to modify..."
+            )
         elif target == "ALL_DEFINED":
             info(">>> Getting ALL groups and projects DEFINED in the configuration...")
         else:

--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -562,9 +562,9 @@ class GitLabForm:
         """
 
         if target == "ALL":
-            info(">>> Getting ALL groups and projects...")
+            info(">>> Getting ALL groups and projects that I can modify...")
         elif target == "ALL_DEFINED":
-            info(">>> Getting all groups and projects defined in the configuration...")
+            info(">>> Getting ALL groups and projects DEFINED in the configuration...")
         else:
             info(">>> Getting requested groups or projects...")
 

--- a/gitlabform/gitlab/core.py
+++ b/gitlabform/gitlab/core.py
@@ -8,7 +8,7 @@ import requests
 
 # noinspection PyPackageRequirements
 import urllib3
-from cli_ui import debug as verbose
+from cli_ui import debug as verbose, warning
 from requests.adapters import HTTPAdapter
 
 # noinspection PyPackageRequirements
@@ -58,6 +58,18 @@ class GitLabCore:
                 f"Connected to GitLab version: {version['version']} ({version['revision']})"
             )
             self.version = version["version"]
+
+            current_user = self._make_requests_to_api("user")
+            if current_user.get("is_admin", False):
+                self.admin = True
+            else:
+                self.admin = False
+            verbose(
+                f"Connected as: {current_user['username']}, admin: {'yes' if self.admin else 'no'}"
+            )
+            if not self.admin:
+                warning("Connected as non-admin. You may encounter permission issues.")
+
         except Exception as e:
             raise TestRequestFailedException(e)
 

--- a/gitlabform/processors/__init__.py
+++ b/gitlabform/processors/__init__.py
@@ -28,21 +28,10 @@ class AbstractProcessors(ABC):
     ):
         for processor in self.processors:
             if only_sections == "all" or processor.configuration_name in only_sections:
-                try:
-                    processor.process(
-                        entity_reference,
-                        configuration,
-                        dry_run,
-                        effective_configuration,
-                    )
-                except requests.exceptions.ConnectionError as e:
-                    if (
-                        "RemoteDisconnected('Remote end closed connection without response')"
-                        in str(e)
-                    ):
-                        print("thats the case")
-
-        else:
-            verbose(
-                f"Skipping section '{processor.configuration_name}' - not in --only-sections list."
-            )
+                processor.process(
+                    entity_reference, configuration, dry_run, effective_configuration
+                )
+            else:
+                verbose(
+                    f"Skipping section '{processor.configuration_name}' - not in --only-sections list."
+                )


### PR DESCRIPTION
and improve behavior in other cases when running as
a non-admin. In that case there is no point in trying
to get all groups or projects as you need at least
Reporter role to change their configuration.

Fixes: https://github.com/gitlabform/gitlabform/issues/509