### PR TITLE
#454 Keep bot members in place regardless of "enforce" setting

### DIFF
--- a/docs/reference/members.md
+++ b/docs/reference/members.md
@@ -4,11 +4,12 @@ These sections are for managing the users and groups that are [members of a proj
 
 ## Project members
 
-There are 3 keys that can be set in the `members` section:
+There are 4 keys that can be set in the `members` section:
 
 * `groups` - to make other groups members of a given group. Here the key names are group paths and values are as described in the [share project with a group endpoint of the Projects API](https://docs.gitlab.com/ee/api/projects.html#share-project-with-group),
 * `users` - to add single users. Here the key names are usernames and the values are as described in the [add member to a group or project endpoint of the Group and project members API](https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project),
 * `enforce` - if set to `true` then this project will have ONLY the users and groups listed in the configuration as the *direct* members (so this setting will NOT affect the members inherited f.e. from a group that contains this project); default is `false`.
+* `keep_bots` - if set to `true` then any existing project members that are bots will _not_ be removed regardless of the `enforce` setting; default is `false`.
 
 Note: there has to be at least 1 user/group with "owner" access level per project - it's required by GitLab.
 
@@ -28,15 +29,17 @@ projects_and_groups:
           access_level: maintainer
           expires_at: 2025-09-26
       enforce: true
+      keep_bots: true
 ```
 
 ## Group members
 
-There are 3 keys that can be set in the `group_members` section:
+There are 4 keys that can be set in the `group_members` section:
 
 * `groups` - to make other groups members of a given group. Here the key names are group paths and values are as described in the [create a link to share a group with another group endpoint of the Groups API](https://docs.gitlab.com/ee/api/groups.html#create-a-link-to-share-a-group-with-another-group),
 * `users` - to add single users. Here the key names are usernames and the values are as described in the [add member to a group or project endpoint of the Group and project members API](https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project),
 * `enforce` - if set to `true` then removing a user or group from this config will also remove them from the group (so this setting will NOT affect the members inherited f.e. from a group that contains this group); default is `false`.
+* `keep_bots` - if set to `true` then any existing group members that are bots will _not_ be removed regardless of the `enforce` setting; default is `false`.
 
 Note: there has to be at least 1 user/group with "owner" access level per group - it's required by GitLab.
 
@@ -53,4 +56,5 @@ projects_and_groups:
         my-user:
           access_level: owner
       enforce: true
+      keep_bots: false
 ```

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -6,7 +6,7 @@ from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
 from gitlab import Gitlab
-from gitlab.v4.objects import Group, Project, User, ProjectAccessToken
+from gitlab.v4.objects import Group, Project, User, ProjectAccessToken, GroupAccessToken
 
 from gitlabform.gitlab import AccessLevel, GitLab
 from tests.acceptance import (
@@ -258,6 +258,35 @@ def make_project_access_token(
     for token in created_tokens:
         with allowed_codes(404):
             project.access_tokens.delete(token.id)
+
+
+@pytest.fixture(scope="class")
+def make_group_access_token(
+    group,
+) -> Generator[Callable[[AccessLevel, List[str]], GroupAccessToken], None, None]:
+    token_name_base = get_random_name("user")
+    created_tokens: List[GroupAccessToken] = []
+
+    def _make_group_access_token(
+        level: AccessLevel = AccessLevel.DEVELOPER, scopes: List[str] = ["api"]
+    ) -> GroupAccessToken:
+        last_id = len(created_tokens) + 1
+        token_name = f"{token_name_base}_{last_id}_bot"
+        token = group.access_tokens.create(
+            {
+                "access_level": level,
+                "name": token_name,
+                "scopes": scopes,
+            }
+        )
+        created_tokens.append(token)
+        return token
+
+    yield _make_group_access_token
+
+    for token in created_tokens:
+        with allowed_codes(404):
+            group.access_tokens.delete(token.id)
 
 
 @pytest.fixture(scope="class")

--- a/tests/acceptance/standard/test_members_enforce.py
+++ b/tests/acceptance/standard/test_members_enforce.py
@@ -1,7 +1,21 @@
+import pytest
+
 from gitlabform.gitlab import AccessLevel
 from tests.acceptance import (
     run_gitlabform,
 )
+
+
+@pytest.fixture(scope="function")
+def bot_members(gl, make_project_access_token, make_user):
+    token = make_project_access_token()
+
+    member1 = gl.users.get(token.user_id)
+    member2 = make_user()
+
+    yield [member1.username, member2.username]
+
+    token.delete()
 
 
 class TestMembersEnforce:
@@ -33,3 +47,34 @@ class TestMembersEnforce:
 
         assert len(members) == 1
         assert members[0].username == outsider_user.username
+
+    def test__enforce_keep_bots(
+        self,
+        project,
+        bot_members,
+        outsider_user,
+    ):
+        members_before = project.members.list()
+        assert len(members_before) == 2
+
+        members_usernames_before = [member.username for member in members_before]
+        assert outsider_user.username not in members_usernames_before
+
+        enforce_users = f"""
+            projects_and_groups:
+              {project.path_with_namespace}:
+                members:
+                  users:
+                    {outsider_user.username}: # new user
+                      access_level: {AccessLevel.MAINTAINER.value}
+                  enforce: true
+                  keep_bots: true
+            """
+
+        run_gitlabform(enforce_users, project)
+
+        members = project.members.list()
+
+        assert len(members) == 2
+        assert members[0].username == bot_members[0]
+        assert members[1].username == outsider_user.username


### PR DESCRIPTION
This PR aims to address the issue described in #454. I've gone for a `keep_bots` option which seems more descriptive of what it actual does, rather than the `ignore_bot_members` mentioned in the original issue. Happy to change this is if needs be.

Python isn't my first language so I've largely picked through what exists already and taken a steer from that. Any guidance on improvements would be much appreciated :)