### PR TITLE
feat: add allowed_to_create support for tag protection

### DIFF
--- a/docs/reference/tags_protection.md
+++ b/docs/reference/tags_protection.md
@@ -4,6 +4,8 @@ This section purpose is to protect and unprotect the project tags.
 
 It works using the [Protected tags API](https://docs.gitlab.com/ee/api/protected_tags.html#protect-repository-tags) and its syntax is loosely based on it.
 
+## Common features
+
 The keys are the exact names of the tag or wildcards.
 
 The values are:
@@ -22,4 +24,45 @@ projects_and_groups:
         create_access_level: developer
       "some-old-tag":
         protected: false
+```
+
+## Premium-only features
+
+!!! info
+
+    Below syntax and features require GitLab Premium (paid). (This is a GitLab's limitation, not GitLabForm's.)
+
+In GitLab Premium instances you can also use the following extra keys under each branch:
+
+* `allowed_to_create` key that can be set to the arrays containing any combination of:
+    * `user` set to username,
+    * `user_id` set to user id,
+    * `group` set to group name (path),
+    * `group_id` set to group id,
+    * `access_level` set to [valid access level](https://docs.gitlab.com/ee/api/members.html#valid-access-levels)
+
+Note that you should NOT use both `create_access_level` and `access_level` key under `allowed_to_create` - the result could be ambiguous, please choose the first or the second set.
+
+Example:
+
+```yaml
+projects_and_groups:
+  group_1/project_1:
+    tags:
+      # Allow specific users, groups, or roles to create this tag
+      release-*:
+        protected: true
+        allowed_to_create:
+          - user: jsmith # you can use usernames...
+          - user: bdoe
+          - group: another-group # ...or group names (paths)...
+          - user_id: 15 # ...or user ids, if you know them...
+          - group_id: 456 # ...or group ids, if you know them...
+          - access_level: no access # do not allow creating tag by role (only specific user or group)
+      alpha-release-by-devs-*:
+        protected: true
+        allowed_to_create:
+          - access_level: developer
+          - user: jsmith # you can use usernames...
+          - user: 15
 ```

--- a/gitlabform/gitlab/tags.py
+++ b/gitlabform/gitlab/tags.py
@@ -21,16 +21,19 @@ class GitLabTags(GitLabCore):
             project_and_group_name,
         )
 
-    def protect_tag(self, project_and_group_name, tag_name, create_access_level):
-        data = {"name": tag_name}
+    def protect_tag(
+        self, project_and_group_name, tag_name, allowed_to_create, create_access_level
+    ):
+        data = {}
+        if allowed_to_create is not None:
+            data["allowed_to_create"] = allowed_to_create
         if create_access_level is not None:
             data["create_access_level"] = create_access_level
+
+        url = "projects/%s/protected_tags?name=%s"
+        parameters_list = [project_and_group_name, tag_name]
         return self._make_requests_to_api(
-            "projects/%s/protected_tags",
-            project_and_group_name,
-            method="POST",
-            data=data,
-            expected_codes=201,
+            url, tuple(parameters_list), method="POST", expected_codes=201, json=data
         )
 
     def unprotect_tag(self, project_and_group_name, tag_name):

--- a/gitlabform/processors/project/tags_processor.py
+++ b/gitlabform/processors/project/tags_processor.py
@@ -16,6 +16,40 @@ class TagsProcessor(AbstractProcessor):
         for tag in sorted(configuration["tags"]):
             try:
                 if configuration["tags"][tag]["protected"]:
+                    allowed_to_create = []
+
+                    if "allowed_to_create" in configuration["tags"][tag]:
+                        access_levels = set()
+                        user_ids = set()
+                        group_ids = set()
+
+                        requested_configuration = configuration["tags"][tag][
+                            "allowed_to_create"
+                        ]
+
+                        for config in requested_configuration:
+                            if "access_level" in config:
+                                access_levels.add(config["access_level"])
+                            elif "user_id" in config:
+                                user_ids.add(config["user_id"])
+                            elif "user" in config:
+                                user_ids.add(self.gitlab._get_user_id(config["user"]))
+                            elif "group_id" in config:
+                                group_ids.add(config["group_id"])
+                            elif "group" in config:
+                                group_ids.add(
+                                    self.gitlab._get_group_id(config["group"])
+                                )
+
+                        for val in access_levels:
+                            allowed_to_create.append({"access_level": val})
+
+                        for val in user_ids:
+                            allowed_to_create.append({"user_id": val})
+
+                        for val in group_ids:
+                            allowed_to_create.append({"group_id": val})
+
                     create_access_level = (
                         configuration["tags"][tag]["create_access_level"]
                         if "create_access_level" in configuration["tags"][tag]
@@ -27,7 +61,9 @@ class TagsProcessor(AbstractProcessor):
                         self.gitlab.unprotect_tag(project_and_group, tag)
                     except NotFoundException:
                         pass
-                    self.gitlab.protect_tag(project_and_group, tag, create_access_level)
+                    self.gitlab.protect_tag(
+                        project_and_group, tag, allowed_to_create, create_access_level
+                    )
                 else:
                     debug("Setting tag '%s' as *unprotected*", tag)
                     self.gitlab.unprotect_tag(project_and_group, tag)

--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -210,6 +210,39 @@ def get_only_branch_access_levels(project: Project, branch):
     )
 
 
+def get_only_tag_access_levels(project: Project, tag):
+    protected_tag = None
+
+    with allowed_codes(404):
+        protected_tag = project.protectedtags.get(tag)
+
+    if not protected_tag:
+        return None, None, None
+
+    allowed_to_create_access_levels = set()
+    allowed_to_create_access_user_ids = set()
+    allowed_to_create_access_group_ids = set()
+
+    tag_details = protected_tag.attributes
+
+    if "create_access_levels" in tag_details:
+        for create_access in tag_details["create_access_levels"]:
+            if create_access["user_id"]:
+                allowed_to_create_access_user_ids.add(create_access["user_id"])
+
+            if create_access["group_id"]:
+                allowed_to_create_access_group_ids.add(create_access["group_id"])
+
+            if not create_access["user_id"] and not create_access["group_id"]:
+                allowed_to_create_access_levels.add(create_access["access_level"])
+
+    return (
+        sorted(allowed_to_create_access_levels),
+        sorted(allowed_to_create_access_user_ids),
+        sorted(allowed_to_create_access_group_ids),
+    )
+
+
 def run_gitlabform(config, target, include_archived_projects=True):
     # f-strings with """ used as configs have the disadvantage of having indentation in them - let's remove it here
     config = textwrap.dedent(config)

--- a/tests/acceptance/premium/test_tags.py
+++ b/tests/acceptance/premium/test_tags.py
@@ -1,0 +1,258 @@
+import pytest
+import gitlab
+
+from gitlabform.gitlab import AccessLevel
+from tests.acceptance import get_only_tag_access_levels, run_gitlabform
+
+pytestmark = pytest.mark.requires_license
+
+
+class TestTags:
+    def test__allowed_to_create_by_user_only(self, project, tag, make_user):
+        user1 = make_user(AccessLevel.DEVELOPER)
+        user2 = make_user(AccessLevel.DEVELOPER)
+
+        config_tag_protection_allowed_to_create = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            tags:
+              {tag}:
+                protected: true
+                allowed_to_create:
+                  - access_level: {AccessLevel.NO_ACCESS.value}
+                  - user_id: {user1.id}
+                  - user: {user2.username}
+        """
+
+        run_gitlabform(config_tag_protection_allowed_to_create, project)
+        (
+            allowed_to_create_access_levels,
+            allowed_to_create_access_user_ids,
+            allowed_to_create_access_group_ids,
+        ) = get_only_tag_access_levels(project, tag)
+
+        assert allowed_to_create_access_levels == sorted([AccessLevel.NO_ACCESS.value])
+        assert allowed_to_create_access_user_ids == sorted([user1.id, user2.id])
+        assert allowed_to_create_access_group_ids == []
+
+    def test__allowed_to_create_by_user_but_without_explicit_role_config(
+        self, project, tag, make_user
+    ):
+        user1 = make_user(AccessLevel.DEVELOPER)
+        user2 = make_user(AccessLevel.DEVELOPER)
+
+        config_tag_protection_allowed_to_create = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            tags:
+              {tag}:
+                protected: true
+                allowed_to_create:
+                  - user_id: {user1.id}
+                  - user: {user2.username}
+        """
+
+        run_gitlabform(config_tag_protection_allowed_to_create, project)
+        (
+            allowed_to_create_access_levels,
+            allowed_to_create_access_user_ids,
+            allowed_to_create_access_group_ids,
+        ) = get_only_tag_access_levels(project, tag)
+
+        assert allowed_to_create_access_levels == []
+        assert allowed_to_create_access_user_ids == sorted([user1.id, user2.id])
+        assert allowed_to_create_access_group_ids == []
+
+    def test__allowed_to_create_by_user_and_role(self, project, tag, make_user):
+        user1 = make_user(AccessLevel.DEVELOPER)
+
+        config_tag_protection_allowed_to_create = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            tags:
+              {tag}:
+                protected: true
+                allowed_to_create:
+                  - access_level: {AccessLevel.MAINTAINER.value}
+                  - user: {user1.username}
+        """
+
+        run_gitlabform(config_tag_protection_allowed_to_create, project)
+        (
+            allowed_to_create_access_levels,
+            allowed_to_create_access_user_ids,
+            allowed_to_create_access_group_ids,
+        ) = get_only_tag_access_levels(project, tag)
+
+        assert allowed_to_create_access_levels == sorted(
+            [
+                AccessLevel.MAINTAINER.value,
+            ]
+        )
+        assert allowed_to_create_access_user_ids == sorted([user1.id])
+        assert allowed_to_create_access_group_ids == []
+
+    def test__allowed_to_create_by_group_only(
+        self, project, tag, group_to_invite_to_project
+    ):
+        shared_group1 = group_to_invite_to_project(project, AccessLevel.DEVELOPER)
+        shared_group2 = group_to_invite_to_project(project, AccessLevel.MAINTAINER)
+
+        config_tag_protection_allowed_to_create = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            tags:
+              {tag}:
+                protected: true
+                allowed_to_create:
+                  - access_level: {AccessLevel.NO_ACCESS.value}
+                  - group_id: {shared_group1.id}
+                  - group: {shared_group2.name}
+        """
+
+        run_gitlabform(config_tag_protection_allowed_to_create, project)
+        (
+            allowed_to_create_access_levels,
+            allowed_to_create_access_user_ids,
+            allowed_to_create_access_group_ids,
+        ) = get_only_tag_access_levels(project, tag)
+
+        assert allowed_to_create_access_levels == sorted(
+            [
+                AccessLevel.NO_ACCESS.value,
+            ]
+        )
+        assert allowed_to_create_access_user_ids == []
+        assert allowed_to_create_access_group_ids == sorted(
+            [shared_group1.id, shared_group2.id]
+        )
+
+    def test__allowed_to_create_by_user_and_group_only(
+        self, project, tag, make_user, group_to_invite_to_project
+    ):
+        user1 = make_user(AccessLevel.DEVELOPER)
+        user2 = make_user(AccessLevel.DEVELOPER)
+        shared_group1 = group_to_invite_to_project(project, AccessLevel.DEVELOPER)
+        shared_group2 = group_to_invite_to_project(project, AccessLevel.MAINTAINER)
+
+        config_tag_protection_allowed_to_create = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            tags:
+              {tag}:
+                protected: true
+                allowed_to_create:
+                  - access_level: {AccessLevel.NO_ACCESS.value}
+                  - user_id: {user1.id}
+                  - user: {user2.username}
+                  - group_id: {shared_group1.id}
+                  - group: {shared_group2.name}
+        """
+
+        run_gitlabform(config_tag_protection_allowed_to_create, project)
+        (
+            allowed_to_create_access_levels,
+            allowed_to_create_access_user_ids,
+            allowed_to_create_access_group_ids,
+        ) = get_only_tag_access_levels(project, tag)
+
+        assert allowed_to_create_access_levels == sorted(
+            [
+                AccessLevel.NO_ACCESS.value,
+            ]
+        )
+        assert allowed_to_create_access_user_ids == sorted([user1.id, user2.id])
+        assert allowed_to_create_access_group_ids == sorted(
+            [shared_group1.id, shared_group2.id]
+        )
+
+    def test__allowed_to_create_by_user_and_group_and_role(
+        self, project, tag, make_user, group_to_invite_to_project
+    ):
+        user1 = make_user(AccessLevel.DEVELOPER)
+        user2 = make_user(AccessLevel.DEVELOPER)
+        shared_group1 = group_to_invite_to_project(project, AccessLevel.DEVELOPER)
+        shared_group2 = group_to_invite_to_project(project, AccessLevel.MAINTAINER)
+
+        config_tag_protection_allowed_to_create = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            tags:
+              {tag}:
+                protected: true
+                allowed_to_create:
+                  - access_level: {AccessLevel.DEVELOPER.value}
+                  - access_level: {AccessLevel.MAINTAINER.value}
+                  - user_id: {user1.id}
+                  - user: {user2.username}
+                  - group_id: {shared_group1.id}
+                  - group: {shared_group2.name}
+        """
+
+        run_gitlabform(config_tag_protection_allowed_to_create, project)
+        (
+            allowed_to_create_access_levels,
+            allowed_to_create_access_user_ids,
+            allowed_to_create_access_group_ids,
+        ) = get_only_tag_access_levels(project, tag)
+
+        assert allowed_to_create_access_levels == sorted(
+            [AccessLevel.DEVELOPER.value, AccessLevel.MAINTAINER.value]
+        )
+        assert allowed_to_create_access_user_ids == sorted([user1.id, user2.id])
+        assert allowed_to_create_access_group_ids == sorted(
+            [shared_group1.id, shared_group2.id]
+        )
+
+    def test__allowed_to_create_by_dev_role_only(self, project, tag):
+        config_tag_protection_allowed_to_create = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            tags:
+              {tag}:
+                protected: true
+                allowed_to_create:
+                  - access_level: {AccessLevel.DEVELOPER.value}
+        """
+
+        run_gitlabform(config_tag_protection_allowed_to_create, project)
+        (
+            allowed_to_create_access_levels,
+            allowed_to_create_access_user_ids,
+            allowed_to_create_access_group_ids,
+        ) = get_only_tag_access_levels(project, tag)
+
+        assert allowed_to_create_access_levels == sorted(
+            [
+                AccessLevel.DEVELOPER.value,
+            ]
+        )
+        assert allowed_to_create_access_user_ids == []
+        assert allowed_to_create_access_group_ids == []
+
+    def test__access_level_role_by_mixed_config(self, project, tag):
+        config_tag_protection_allowed_to_create_and_create_access_level = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            tags:
+              {tag}:
+                protected: true
+                create_access_level: {AccessLevel.MAINTAINER.value}
+                allowed_to_create:
+                  - access_level: {AccessLevel.DEVELOPER.value}
+        """
+
+        run_gitlabform(
+            config_tag_protection_allowed_to_create_and_create_access_level, project
+        )
+        (
+            allowed_to_create_access_levels,
+            allowed_to_create_access_user_ids,
+            allowed_to_create_access_group_ids,
+        ) = get_only_tag_access_levels(project, tag)
+
+        assert allowed_to_create_access_levels == sorted(
+            [AccessLevel.DEVELOPER.value, AccessLevel.MAINTAINER.value]
+        )
+        assert allowed_to_create_access_user_ids == []
+        assert allowed_to_create_access_group_ids == []


### PR DESCRIPTION
Currently `gitlabform` does not support [configuring tag protection](https://docs.gitlab.com/ee/user/project/protected_tags.html#configuring-protected-tags) using specific user(s) or group(s) as "Allowed to create". Only basic role can be set, such as: developer, maintainer, etc. Selecting individual user or group is a feature of Premium or Ultimate license.

This change adds the ability to configure tag protection to be set to individual users or groups. They can be set as a user/group ID or their names. For example with a config like below, a tag named `special-tag-blah` can only be created by either user `Jane.Doe`, or user whose ID is `123` or, users who are member of the group `foo-bar`.

```yaml
projects_and_groups:
  group_1/project_1:
    tags:
      "v*":
        protected: true
        create_access_level: developer
      "special-tag-*":
        protected: true
        allowed_to_create:
          - user: Jane.Doe
          - user_id: 123
          - group: foo-bar
      "some-old-tag":
        protected: false
```

To Dos:

- [x] Implement feature
- [x] Add acceptance test
- [x] Update documentation

closes #505 