### PR TITLE
chore(dev/ci): set expiry date for access token

### DIFF
--- a/dev/healthcheck-and-setup.sh
+++ b/dev/healthcheck-and-setup.sh
@@ -30,7 +30,8 @@ test -f $done || {
     printf 'gitlabform_token = PersonalAccessToken.create('
     printf 'user_id: 1, '
     printf 'scopes: [:api, :read_user], '
-    printf 'name: :gitlabform);'
+    printf 'name: :gitlabform, '
+    printf 'expires_at: 365.days.from_now);'
     printf "gitlabform_token.set_token('token-string-here123');"
     printf 'gitlabform_token.save!;'
   ) | gitlab-rails console


### PR DESCRIPTION
As of GitLab v16.0, all access tokens must have an expiry date. Otherwise the access token will not be created. This wasn't being done in the script that sets up a GitLab instances with an access token so that the token can be used for all acceptance tests via API calls. This worked fine before but started failing recently when latest version of GitLab was being used in the CI because the latest version is 16 and up. As a result, all the PR validations are failing because the acceptance tests are failing with '401 Unauthorized' error.