### PR TITLE
Retry requests to codecov

### DIFF
--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -56,9 +56,13 @@ jobs:
           ./dev/run_gitlab_in_docker.sh
           pytest --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 tests/acceptance/standard
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: Wandalen/wretry.action@v1
         with:
-          fail_ci_if_error: true
+          action: codecov/codecov-action@v3
+          with: |
+            fail_ci_if_error: true
+          attempt_limit: 5
+          attempt_delay: 10000
 
   acceptance-tests-premium:
     runs-on: ubuntu-latest
@@ -84,9 +88,13 @@ jobs:
           ./dev/run_gitlab_in_docker.sh
           pytest --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 tests/acceptance/premium
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: Wandalen/wretry.action@v1
         with:
-          fail_ci_if_error: true
+          action: codecov/codecov-action@v3
+          with: |
+            fail_ci_if_error: true
+          attempt_limit: 5
+          attempt_delay: 10000
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -109,9 +117,13 @@ jobs:
         run: |
           pytest --cov=. --cov-report=xml tests/unit
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: Wandalen/wretry.action@v1
         with:
-          fail_ci_if_error: true
+          action: codecov/codecov-action@v3
+          with: |
+            fail_ci_if_error: true
+          attempt_limit: 5
+          attempt_delay: 10000
 
   security-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-linter-and-tests.yml
+++ b/.github/workflows/pr-linter-and-tests.yml
@@ -71,11 +71,15 @@ jobs:
           ./dev/run_gitlab_in_docker.sh
           pytest --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 tests/acceptance/standard
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: Wandalen/wretry.action@v1
         with:
-          fail_ci_if_error: false
-          override_pr: ${{ github.event.number }}
-          override_commit: ${{ github.event.pull_request.head.sha }}
+          action: codecov/codecov-action@v3
+          with: |
+            fail_ci_if_error: true
+            override_pr: ${{ github.event.number }}
+            override_commit: ${{ github.event.pull_request.head.sha }}
+          attempt_limit: 5
+          attempt_delay: 10000
 
   acceptance-tests-premium:
     runs-on: ubuntu-latest
@@ -110,11 +114,15 @@ jobs:
           ./dev/run_gitlab_in_docker.sh
           pytest --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 tests/acceptance/premium
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: Wandalen/wretry.action@v1
         with:
-          fail_ci_if_error: false
-          override_pr: ${{ github.event.number }}
-          override_commit: ${{ github.event.pull_request.head.sha }}
+          action: codecov/codecov-action@v3
+          with: |
+            fail_ci_if_error: true
+            override_pr: ${{ github.event.number }}
+            override_commit: ${{ github.event.pull_request.head.sha }}
+          attempt_limit: 5
+          attempt_delay: 10000
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -141,11 +149,15 @@ jobs:
         run: |
           pytest --cov=. --cov-report=xml tests/unit
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: Wandalen/wretry.action@v1
         with:
-          fail_ci_if_error: false
-          override_pr: ${{ github.event.number }}
-          override_commit: ${{ github.event.pull_request.head.sha }}
+          action: codecov/codecov-action@v3
+          with: |
+            fail_ci_if_error: true
+            override_pr: ${{ github.event.number }}
+            override_commit: ${{ github.event.pull_request.head.sha }}
+          attempt_limit: 5
+          attempt_delay: 10000
 
   security-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
to avoid failure of the whole pipeline on
intermitten codecov backend issues.

Uses a workaround provided by @LucasXu0
in https://github.com/codecov/codecov-action/issues/926.