### PR TITLE
chore: fix incompatible type in test fixture

### DIFF
--- a/.github/workflows/pr-linter-and-tests.yml
+++ b/.github/workflows/pr-linter-and-tests.yml
@@ -30,7 +30,11 @@ jobs:
   types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code from the PR
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -153,11 +153,15 @@ def groups(users):
 
 
 @pytest.fixture(scope="class")
-def group_to_invite_to_project(gl: Gitlab) -> Generator[Optional[Group], None, None]:
+def group_to_invite_to_project(
+    gl: Gitlab,
+) -> Generator[Callable[[Project, AccessLevel], Group], None, None]:
     group_name_base = get_random_name("group")
     created_groups: List[Group] = []
 
-    def _group_to_invite_to_project(project, access_level):
+    def _group_to_invite_to_project(
+        project: Project, access_level: AccessLevel = AccessLevel.DEVELOPER
+    ) -> Group:
         group_index = len(created_groups) + 1
         group_name = f"{group_name_base}_{group_index}"
         gitlab_group = create_group(group_name)


### PR DESCRIPTION
This PR is related to #551 . In that PR the GitHub CI was fine, but after merging the change found out "type" issue in test fixture reported by `mypy`. See https://github.com/gitlabform/gitlabform/actions/runs/5617292516/job/15221155542

Not sure why the issue wasn't originally caught in the PR's CI but I had also missed running the `mypy` locally to validate it.

This PR addresses the type issue so that we have a clean codebase.
