### PR TITLE
test: stabilize intermittent issue with enforce_keep_bots test

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -281,12 +281,12 @@ def make_project_access_token(
     created_tokens: List[ProjectAccessToken] = []
 
     def _make_project_access_token(
-        level: AccessLevel = AccessLevel.DEVELOPER, scopes: List[str] = ["api"]
+        target_project: Project = project, level: AccessLevel = AccessLevel.DEVELOPER, scopes: List[str] = ["api"]
     ) -> ProjectAccessToken:
         last_id = len(created_tokens) + 1
         token_name = f"{token_name_base}_{last_id}_bot"
         expires_at = (date.today() + timedelta(days=30)).isoformat()
-        token = project.access_tokens.create(
+        token = target_project.access_tokens.create(
             {
                 "access_level": level,
                 "name": token_name,

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -276,12 +276,16 @@ def make_user(
 @pytest.fixture(scope="class")
 def make_project_access_token(
     project,
-) -> Generator[Callable[[AccessLevel, List[str]], ProjectAccessToken], None, None]:
+) -> Generator[
+    Callable[[Project, AccessLevel, List[str]], ProjectAccessToken], None, None
+]:
     token_name_base = get_random_name("user")
     created_tokens: List[ProjectAccessToken] = []
 
     def _make_project_access_token(
-        target_project: Project = project, level: AccessLevel = AccessLevel.DEVELOPER, scopes: List[str] = ["api"]
+        target_project=project,
+        level: AccessLevel = AccessLevel.DEVELOPER,
+        scopes: List[str] = ["api"],
     ) -> ProjectAccessToken:
         last_id = len(created_tokens) + 1
         token_name = f"{token_name_base}_{last_id}_bot"

--- a/tests/acceptance/standard/test_members_enforce.py
+++ b/tests/acceptance/standard/test_members_enforce.py
@@ -8,7 +8,7 @@ from tests.acceptance import (
 
 @pytest.fixture(scope="function")
 def bot_member(gl, make_project_access_token, project_for_function):
-    token = make_project_access_token(target_project = project_for_function)
+    token = make_project_access_token(target_project=project_for_function)
 
     bot_member = gl.users.get(token.user_id)
 

--- a/tests/acceptance/standard/test_members_enforce.py
+++ b/tests/acceptance/standard/test_members_enforce.py
@@ -7,13 +7,12 @@ from tests.acceptance import (
 
 
 @pytest.fixture(scope="function")
-def bot_members(gl, make_project_access_token, make_user):
-    token = make_project_access_token()
+def bot_member(gl, make_project_access_token, project_for_function):
+    token = make_project_access_token(target_project = project_for_function)
 
-    member1 = gl.users.get(token.user_id)
-    member2 = make_user()
+    bot_member = gl.users.get(token.user_id)
 
-    yield [member1.username, member2.username]
+    yield bot_member
 
     token.delete()
 
@@ -26,7 +25,7 @@ class TestMembersEnforce:
         outsider_user,
     ):
         members_before = project.members.list()
-        assert len(members_before) > 0
+        assert len(members_before) == len(three_members)
 
         members_usernames_before = [member.username for member in members_before]
         assert outsider_user.username not in members_usernames_before
@@ -50,19 +49,19 @@ class TestMembersEnforce:
 
     def test__enforce_keep_bots(
         self,
-        project,
-        bot_members,
+        project_for_function,
+        bot_member,
         outsider_user,
     ):
-        members_before = project.members.list()
-        assert len(members_before) == 2
+        members_before = project_for_function.members.list()
+        assert len(members_before) == 1
 
         members_usernames_before = [member.username for member in members_before]
         assert outsider_user.username not in members_usernames_before
 
         enforce_users = f"""
             projects_and_groups:
-              {project.path_with_namespace}:
+              {project_for_function.path_with_namespace}:
                 members:
                   users:
                     {outsider_user.username}: # new user
@@ -71,10 +70,9 @@ class TestMembersEnforce:
                   keep_bots: true
             """
 
-        run_gitlabform(enforce_users, project)
+        run_gitlabform(enforce_users, project_for_function)
 
-        members = project.members.list()
+        members = project_for_function.members.list()
 
         assert len(members) == 2
-        assert members[0].username == bot_members[0]
-        assert members[1].username == outsider_user.username
+        assert members[0].username == bot_member.username


### PR DESCRIPTION
This PR is related to `test__enforce_keep_bots` test case that intermittently fails but it does so quite often in GitHub Actions CI.

I was able to reproduce the issue locally too. The failure happens about 3 out of 5 runs of the test. In my local run, the failure was around asserting that the project has 2 members (i.e. test was getting 3 instead).

After a bit of debugging, I noticed that this test uses the same `project` fixture as the test (`test__enforce`) that runs before it. In that test, an additional user is added for validating that the `enforce: true` is working. Since the `project` fixture is scoped to a class, this project is also available to the `test__enforce_keep_bots` test.

When the intermittent issue does show up, the project's members still contains the user that was added via gitlabform config. Not sure why this user is intermittently available for the next test though. This is confusing to me.

To keep things a bit more isolated, in this PR I updated the 2nd test case (`test__enforce_keep_bots`) to use `project_for_function` fixture. This way the tests aren't sharing the same project. To accommodate for this change, I updated the `make_project_access_token` fixture so that we can tell it which project's access token should be created, as an optional parameter. Also refactored the `bot_members` fixture because it was adding a regular user to the project in addition to a project access token, which can lead to further confusions in the future.

With my change in this PR, I ran the test locally 10 times and didn't see the intermittent failures. Hopefully in Github CI, the test passes in first attempt. We should also try running it in this PR a few times for extra validations.


closes #569 