### PR TITLE
chore(python): drop support for python 3.7

### DIFF
--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
       fail-fast : false
     steps:
       - uses: actions/checkout@v3
@@ -103,7 +103,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
       fail-fast : false
     steps:
       - uses: actions/checkout@v3
@@ -149,7 +149,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
       fail-fast : false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr-linter-and-tests.yml
+++ b/.github/workflows/pr-linter-and-tests.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
       fail-fast : false
     steps:
       - name: Checkout code from the PR
@@ -135,7 +135,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
       fail-fast : false
     steps:
       - name: Checkout code from the PR
@@ -191,7 +191,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
       fail-fast : false
     steps:
       - name: Checkout code from the PR

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,5 +1,5 @@
 # Requirements
 
-* Docker or Python 3.7-3.11
+* Docker or Python 3.8-3.11
 * Self-Hosted GitLab 14.4+ or SaaS GitLab @ gitlab.com
     * Premium (paid) license for some features

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     author="Greg Dubicki and Contributors",
     keywords=["cli", "yaml", "gitlab", "configuration-as-code"],
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -42,7 +41,7 @@ setup(
     packages=find_packages(),
     package_data={"": ["LICENSE", "version", "*.md", "config.yml"]},
     include_package_data=True,
-    python_requires=">=3.7.0",
+    python_requires=">=3.8.0",
     install_requires=[
         "certifi",  # we want the latest root certs for security
         "requests==2.31.0",


### PR DESCRIPTION
Python 3.7 has reached EOL (end of life) as of June 2023. See [status of python versions](https://devguide.python.org/versions/). We're already unable to update some of our dependencies as they have also dropped support for python 3.7. For example: #588, #591

This PR drops support for Python 3.7 by gitlabform.

closes #576 
