### PR TITLE
refactor: migrate project:archive feature to use python-gitlab library

### DIFF
--- a/gitlabform/gitlab/projects.py
+++ b/gitlabform/gitlab/projects.py
@@ -247,19 +247,3 @@ class GitLabProjects(GitLabCore):
             method="DELETE",
             expected_codes=[204, 404],
         )
-
-    def archive(self, project_and_group_name):
-        return self._make_requests_to_api(
-            "projects/%s/archive",
-            project_and_group_name,
-            method="POST",
-            expected_codes=[200, 201],
-        )
-
-    def unarchive(self, project_and_group_name):
-        return self._make_requests_to_api(
-            "projects/%s/unarchive",
-            project_and_group_name,
-            method="POST",
-            expected_codes=[200, 201],
-        )

--- a/gitlabform/processors/abstract_processor.py
+++ b/gitlabform/processors/abstract_processor.py
@@ -6,6 +6,8 @@ import requests
 from cli_ui import debug as verbose
 
 from gitlabform.gitlab import GitLab
+from gitlab import Gitlab
+from gitlabform.gitlab import GitlabWrapper
 from gitlabform.output import EffectiveConfigurationFile
 from gitlabform.processors.util.decorators import configuration_to_safe_dict
 
@@ -20,6 +22,7 @@ class AbstractProcessor(ABC):
                 [str, list[dict[str, Union[str, int]]], list[dict[str, int]]], bool
             ],
         ] = {}
+        self.gl: Gitlab = GitlabWrapper(self.gitlab)._gitlab
 
     @configuration_to_safe_dict
     def process(

--- a/gitlabform/processors/project/project_processor.py
+++ b/gitlabform/processors/project/project_processor.py
@@ -11,19 +11,20 @@ class ProjectProcessor(AbstractProcessor):
         super().__init__("project", gitlab)
 
     def _process_configuration(self, project_and_group: str, configuration: dict):
+        project_path_with_namespace: str = project_and_group
+
         if configuration["project"].get("transfer_from") is not None:
             source_project_path_with_namespace = configuration["project"].get(
                 "transfer_from"
             )
-            destination_project_path_with_namespace = project_and_group
 
             # Check if the project was already transfered (i.e. in previous run) or a project with same path already exists
             try:
-                project: Project = self.gl.projects.get(
-                    destination_project_path_with_namespace
+                project_in_config: Project = self.gl.projects.get(
+                    project_path_with_namespace
                 )
                 verbose(
-                    f"Project already exists: '{project.path_with_namespace}'. Ignoring 'transfer_from' config..."
+                    f"Project already exists: '{project_in_config.path_with_namespace}'. Ignoring 'transfer_from' config..."
                 )
             except GitlabGetError:
                 # Project doesn't exist at the destination. Let's process the transfer request
@@ -59,7 +60,6 @@ class ProjectProcessor(AbstractProcessor):
                 #     raise
 
         if configuration["project"].get("archive") is not None:
-            project_path_with_namespace:str = project_and_group
             project: Project = self.gl.projects.get(project_path_with_namespace)
 
             if configuration["project"].get("archive") is True:

--- a/gitlabform/processors/project/project_processor.py
+++ b/gitlabform/processors/project/project_processor.py
@@ -2,8 +2,7 @@ from cli_ui import debug as verbose
 from logging import fatal
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
-from gitlabform.gitlab import GitlabWrapper
-from gitlab import Gitlab, GitlabGetError, GitlabTransferProjectError
+from gitlab import GitlabGetError, GitlabTransferProjectError
 from gitlab.v4.objects import Project
 
 
@@ -17,11 +16,10 @@ class ProjectProcessor(AbstractProcessor):
                 "transfer_from"
             )
             destination_project_path_with_namespace = project_and_group
-            gl: Gitlab = GitlabWrapper(self.gitlab)._gitlab
 
             # Check if the project was already transfered (i.e. in previous run) or a project with same path already exists
             try:
-                project: Project = gl.projects.get(
+                project: Project = self.gl.projects.get(
                     destination_project_path_with_namespace
                 )
                 verbose(
@@ -29,7 +27,7 @@ class ProjectProcessor(AbstractProcessor):
                 )
             except GitlabGetError:
                 # Project doesn't exist at the destination. Let's process the transfer request
-                project_to_be_transferred: Project = gl.projects.get(
+                project_to_be_transferred: Project = self.gl.projects.get(
                     source_project_path_with_namespace
                 )
                 destination_project_path = project_and_group.split("/")[-1]
@@ -38,7 +36,7 @@ class ProjectProcessor(AbstractProcessor):
                     verbose(
                         f"Updating the source project path from '{project_to_be_transferred.path}' to '{destination_project_path}'"
                     )
-                    gl.projects.update(
+                    self.gl.projects.update(
                         project_to_be_transferred.id, {"path": destination_project_path}
                     )
 

--- a/gitlabform/processors/project/project_processor.py
+++ b/gitlabform/processors/project/project_processor.py
@@ -61,9 +61,12 @@ class ProjectProcessor(AbstractProcessor):
                 #     raise
 
         if configuration["project"].get("archive") is not None:
+            project_path_with_namespace:str = project_and_group
+            project: Project = self.gl.projects.get(project_path_with_namespace)
+
             if configuration["project"].get("archive") is True:
                 verbose("Archiving project...")
-                self.gitlab.archive(project_and_group)
+                project.archive()
             elif configuration["project"].get("archive") is False:
                 verbose("Unarchiving project...")
-                self.gitlab.unarchive(project_and_group)
+                project.unarchive()


### PR DESCRIPTION
This PR builds on top of #582 that provided the setup to use  `python-gitlab` library. Refactored the `project:archive` feature's implementation to use the `python-gitlab` library instead of internal methods that called GitLab's API endpoint.

closes #621 
