### PR TITLE
fix: json data with dates not serialized correctly

### DIFF
--- a/gitlabform/util.py
+++ b/gitlabform/util.py
@@ -4,4 +4,4 @@ import json
 def to_str(a_dict: dict) -> str:
     # arguably the most readable form of a dict in a single line
     # is JSON with sorted keys
-    return json.dumps(a_dict, sort_keys=True)
+    return json.dumps(a_dict, sort_keys=True, default=str)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,20 @@
+import datetime
+
+from gitlabform.util import to_str
+
+
+def test_date_stringification():
+    example_project_config = {
+        "members": {
+            "enforce": True,
+            "users": {
+                "project_204_bot": {"access_level": 40},
+                "project_204_bot_211c9f071a88910e7ed518cc5d81436a": {
+                    "access_level": 40,
+                    "expires_at": datetime.date(2024, 12, 12),
+                },
+            },
+        }
+    }
+    output = to_str(example_project_config)
+    assert type(output) is str


### PR DESCRIPTION
The datetime.date object used for access
expiration etc. is not supporting JSON serialization.
Trying to do this for debug output reasons
ends with an exception. The json.dumps() function
offers to specify a default handling of
unsupported types which is utilized here.

Resolves: #654