### PR TITLE
#662 enforce hooks

### DIFF
--- a/docs/reference/webhooks.md
+++ b/docs/reference/webhooks.md
@@ -2,10 +2,8 @@
 
 This section purpose is to manage the [Webhooks](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html) (aka Project Hooks).
 
-The key names here are webhook URLs, except if the key name is `enforce` and is set to `true` - then only the hooks defined here will remain in the project, all other will be deleted.
-The values of the URL keys are parameters described at [edit project hooks endpoint](https://docs.gitlab.com/ee/api/projects.html#edit-project-hook), **except the id and hook_id**.
-
-If the only value is `delete: true` then the given webhook is going to be removed.
+The key names here are webhook URLs, except if the key name is `enforce` and is set to `true` - in this case only the hooks defined here will remain in the project, all other will be deleted. Setting `enforce: false` is the same as omitting it, in which case only webhooks that have the value `delete: true` will be removed.
+The other values of the URL keys are the parameters described at [edit project hooks endpoint](https://docs.gitlab.com/ee/api/projects.html#edit-project-hook), **except the id and hook_id**.
 
 Example:
 ```yaml

--- a/docs/reference/webhooks.md
+++ b/docs/reference/webhooks.md
@@ -2,7 +2,8 @@
 
 This section purpose is to manage the [Webhooks](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html) (aka Project Hooks).
 
-The key names here are webhook URLs and values are as parameters described at [edit project hooks endpoint](https://docs.gitlab.com/ee/api/projects.html#edit-project-hook), **except the id and hook_id**.
+The key names here are webhook URLs, except if the key name is `enforce` and is set to `true` - then only the hooks defined here will remain in the project, all other will be deleted.
+The values of the URL keys are parameters described at [edit project hooks endpoint](https://docs.gitlab.com/ee/api/projects.html#edit-project-hook), **except the id and hook_id**.
 
 If the only value is `delete: true` then the given webhook is going to be removed.
 
@@ -17,4 +18,5 @@ projects_and_groups:
         push_events: false # this is set to true by GitLab API by default
         merge_requests_events: true
         token: some_secret_auth_token
+      enforce: false
 ```

--- a/tests/acceptance/standard/test_hooks.py
+++ b/tests/acceptance/standard/test_hooks.py
@@ -134,3 +134,18 @@ class TestHooksProcessor:
         assert len(gl_hook_urls) == 1
         assert first_url in gl_hook_urls
         assert second_url not in gl_hook_urls
+
+        not_enforce_yaml = f"""
+                projects_and_groups:
+                  {target}:
+                    hooks:
+                      enforce: false
+                      http://www.newhook.org:
+                        merge_requests_events: false
+                        note_events: true
+                """
+        run_gitlabform(not_enforce_yaml, target)
+        gl_hook_urls = [h.url for h in project.hooks.list()]
+        assert len(gl_hook_urls) == 2
+        assert first_url in gl_hook_urls
+        assert "http://www.newhook.org" in gl_hook_urls


### PR DESCRIPTION
Added 'enforce' support for hooks processor. If set to true, all hooks not present in config yaml will be removed. Set to false is the same as omitting it - in this case 'delete: true' has to be set on any hook that should be deleted.
Added 2 tests, enforce to true/false.
Updated documentation section on webhooks.