### PR TITLE
chore: formatting updates via latest version of black formatter

### DIFF
--- a/gitlabform/configuration/transform.py
+++ b/gitlabform/configuration/transform.py
@@ -225,9 +225,9 @@ class AccessLevelsTransformer(ConfigurationTransformer):
                 for node_coordinate in processor.get_nodes(path, mustexist=True):
                     try:
                         access_level_string = str(node_coordinate.node)
-                        node_coordinate.parent[
-                            node_coordinate.parentref
-                        ] = AccessLevel.get_value(access_level_string)
+                        node_coordinate.parent[node_coordinate.parentref] = (
+                            AccessLevel.get_value(access_level_string)
+                        )
                     except KeyError:
                         fatal(
                             f"Configuration string '{access_level_string}' is not one of the valid access levels:"
@@ -255,9 +255,9 @@ class AccessLevelsTransformer(ConfigurationTransformer):
                     if node_coordinate.parentref == "access_level":
                         try:
                             access_level_string = str(node_coordinate.node)
-                            node_coordinate.parent[
-                                node_coordinate.parentref
-                            ] = AccessLevel.get_value(access_level_string)
+                            node_coordinate.parent[node_coordinate.parentref] = (
+                                AccessLevel.get_value(access_level_string)
+                            )
                         except KeyError:
                             fatal(
                                 f"Configuration string '{access_level_string}' is not one of the valid access levels:"
@@ -313,9 +313,9 @@ class MergeRequestApprovalsTransformer(ConfigurationTransformer):
 
                     if old_syntax["approvals"]:
                         # add the settings, if there are left any after removing 'approvals_before_merge'
-                        where_to_add_new_syntax[
-                            "merge_requests_approvals"
-                        ] = old_syntax["approvals"]
+                        where_to_add_new_syntax["merge_requests_approvals"] = (
+                            old_syntax["approvals"]
+                        )
 
                 # approval rules
                 if (

--- a/gitlabform/processors/group/group_members_processor.py
+++ b/gitlabform/processors/group/group_members_processor.py
@@ -70,9 +70,9 @@ class GroupMembersProcessor(AbstractProcessor):
 
         groups_before_by_group_path = dict()
         for share_details in groups_before:
-            groups_before_by_group_path[
-                share_details["group_full_path"]
-            ] = share_details
+            groups_before_by_group_path[share_details["group_full_path"]] = (
+                share_details
+            )
 
         for share_with_group_path in groups_to_set_by_group_path:
             group_access_to_set = groups_to_set_by_group_path[share_with_group_path][

--- a/gitlabform/processors/shared/protected_environments_processor.py
+++ b/gitlabform/processors/shared/protected_environments_processor.py
@@ -17,6 +17,6 @@ class ProtectedEnvironmentsProcessor(MultipleEntitiesProcessor):
             required_to_create_or_update=And(Key("name"), Key("deploy_access_levels")),
         )
 
-        self.custom_diff_analyzers[
-            "deploy_access_levels"
-        ] = self.recursive_diff_analyzer
+        self.custom_diff_analyzers["deploy_access_levels"] = (
+            self.recursive_diff_analyzer
+        )

--- a/gitlabform/processors/util/difference_logger.py
+++ b/gitlabform/processors/util/difference_logger.py
@@ -43,9 +43,9 @@ class DifferenceLogger:
         if hide_entries:
             changes = list(
                 map(
-                    lambda i: [i[0], hide(i[1]), hide(i[2])]
-                    if i[0] in hide_entries
-                    else i,
+                    lambda i: (
+                        [i[0], hide(i[1]), hide(i[2])] if i[0] in hide_entries else i
+                    ),
                     changes,
                 )
             )


### PR DESCRIPTION
The github action uses latest version of `black` when it runs. At the moment, the latest version of `black` is `24.1.1`, which wants to reformat some files that were previously fine as-is with version `23.x`.

Applied the formatting update the files using latest version of `black`.

closes #680 
