### PR TITLE
Lower the amount of PRs created by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    # We only want security updates + all the updates for the below packages
+    # to lower the constant flow of PRs. But this means that occasionally
+    # we need to check our dependencies for update manually!
+    allow:
+      # we want the latest root certs for security
+      - dependency-name: "certifi"
+      # it's our key library, we want it to be very up-to-date
+      - dependency-name: "python-gitlab"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.8.0",
     install_requires=[
-        "certifi",  # we want the latest root certs for security
+        "certifi==2024.2.2",
         "cli-ui==0.17.2",
         "ez-yaml==1.2.0",
         "Jinja2==3.1.3",


### PR DESCRIPTION
We only want security updates PRs +  updates for some key packages

But this change means that occasionally we should check our other dependencies for updates manually!