### PR TITLE
fix: hooks processing fails when config includes token

### DIFF
--- a/gitlabform/processors/project/hooks_processor.py
+++ b/gitlabform/processors/project/hooks_processor.py
@@ -7,7 +7,6 @@ from gitlab.v4.objects import Project
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
 
-from cli_ui import info
 
 class HooksProcessor(AbstractProcessor):
     def __init__(self, gitlab: GitLab):
@@ -41,14 +40,18 @@ class HooksProcessor(AbstractProcessor):
                     debug(f"Created hook: {created_hook}")
                 else:
                     if "token" in hook_config:
-                        debug(f"The hook '{hook}' config includes a token. Diff between config vs gitlab cannot be confirmed")
+                        debug(
+                            f"The hook '{hook}' config includes a token. Diff between config vs gitlab cannot be confirmed"
+                        )
                         debug(f"Updating hook '{hook}'")
                         updated_hook: Dict[str, Any] = project.hooks.update(
                             hook_id, hook_config
                         )
                         debug(f"Updated hook: {updated_hook}")
                     else:
-                        gl_hook: dict = hook_in_gitlab.asdict() if hook_in_gitlab else {}
+                        gl_hook: dict = (
+                            hook_in_gitlab.asdict() if hook_in_gitlab else {}
+                        )
                         diffs = (
                             map(
                                 lambda k: hook_config[k] != gl_hook[k],
@@ -58,11 +61,11 @@ class HooksProcessor(AbstractProcessor):
                             else iter(())
                         )
                         if hook_id and any(diffs):
-                            debug(f"The hook '{hook}' config is different from what's in gitlab")
-                            debug(f"Updating hook '{hook}'")
-                            updated_hook = project.hooks.update(
-                                hook_id, hook_config
+                            debug(
+                                f"The hook '{hook}' config is different from what's in gitlab"
                             )
+                            debug(f"Updating hook '{hook}'")
+                            updated_hook = project.hooks.update(hook_id, hook_config)
                             debug(f"Updated hook: {updated_hook}")
                         elif hook_id and not any(diffs):
                             debug(f"Hook '{hook}' remains unchanged")

--- a/gitlabform/processors/project/hooks_processor.py
+++ b/gitlabform/processors/project/hooks_processor.py
@@ -38,7 +38,7 @@ class HooksProcessor(AbstractProcessor):
                 else:
                     debug(f"Not deleting hook '{hook}', because it doesn't exist")
                 continue
-            
+
             # Process new hook creation
             if not hook_id:
                 debug(f"Creating hook '{hook}'")
@@ -49,7 +49,9 @@ class HooksProcessor(AbstractProcessor):
             # Processing existing hook updates
             gl_hook: dict = hook_in_gitlab.asdict() if hook_in_gitlab else {}
             if self.is_hook_config_different(gl_hook, hook_config):
-                debug(f"The hook '{hook}' config is different from what's in gitlab OR it contains a token")
+                debug(
+                    f"The hook '{hook}' config is different from what's in gitlab OR it contains a token"
+                )
                 debug(f"Updating hook '{hook}'")
                 updated_hook: Dict[str, Any] = project.hooks.update(
                     hook_id, hook_config
@@ -67,11 +69,13 @@ class HooksProcessor(AbstractProcessor):
                     )
                     project.hooks.delete(gh.id)
 
-    def is_hook_config_different(self, config_in_gitlab, config_in_gitlabform):
-        '''
+    def is_hook_config_different(
+        self, config_in_gitlab: dict, config_in_gitlabform: dict
+    ):
+        """
         Compare two dictionary representing a webhook configuration and determine
         if they are different.
-        
+
         GitLab's webhook data does not contain "token" as it is considered a secret.
         If GitLabForm config for a webhook contains a "token", the difference cannot
         be validated. So, an empty value for "token" is used as GitLab's webhook data,
@@ -80,10 +84,10 @@ class HooksProcessor(AbstractProcessor):
         Args:
             config_in_gitlab (dict): hook configuration in gitlab
             config_in_gitlabform (dict): hook configuration in gitlabform
-        
+
         Returns:
             boolean: True if the two configs are different. Otherwise False.
-        '''
+        """
         if "token" in config_in_gitlabform:
             debug(
                 f"The hook '{config_in_gitlabform['url']}' config includes a token. Diff between config vs gitlab cannot be confirmed"

--- a/gitlabform/processors/project/hooks_processor.py
+++ b/gitlabform/processors/project/hooks_processor.py
@@ -78,8 +78,8 @@ class HooksProcessor(AbstractProcessor):
 
         GitLab's webhook data does not contain "token" as it is considered a secret.
         If GitLabForm config for a webhook contains a "token", the difference cannot
-        be validated. So, an empty value for "token" is used as GitLab's webhook data,
-        which will always result in configs being different.
+        be validated. In this case, the config is assumed to be different. Otherwise,
+        the config data will be compared and determined if they are different.
 
         Args:
             config_in_gitlab (dict): hook configuration in gitlab
@@ -90,9 +90,9 @@ class HooksProcessor(AbstractProcessor):
         """
         if "token" in config_in_gitlabform:
             debug(
-                f"The hook '{config_in_gitlabform['url']}' config includes a token. Diff between config vs gitlab cannot be confirmed"
+                f"The hook '{config_in_gitlabform['url']}' config includes a token. Diff between config vs gitlab cannot be confirmed."
             )
-            config_in_gitlab["token"] = ""
+            return True
 
         diffs = (
             map(

--- a/gitlabform/processors/project/hooks_processor.py
+++ b/gitlabform/processors/project/hooks_processor.py
@@ -103,7 +103,4 @@ class HooksProcessor(AbstractProcessor):
             else iter(())
         )
 
-        if any(diffs):
-            return True
-        else:
-            return False
+        return True if any(diffs) else False

--- a/gitlabform/processors/project/hooks_processor.py
+++ b/gitlabform/processors/project/hooks_processor.py
@@ -43,10 +43,10 @@ class HooksProcessor(AbstractProcessor):
                     if "token" in hook_config:
                         debug(f"The hook '{hook}' config includes a token. Diff between config vs gitlab cannot be confirmed")
                         debug(f"Updating hook '{hook}'")
-                        changed_hook: Dict[str, Any] = project.hooks.update(
+                        updated_hook: Dict[str, Any] = project.hooks.update(
                             hook_id, hook_config
                         )
-                        debug(f"Updated hook: {changed_hook}")
+                        debug(f"Updated hook: {updated_hook}")
                     else:
                         gl_hook: dict = hook_in_gitlab.asdict() if hook_in_gitlab else {}
                         diffs = (
@@ -60,10 +60,10 @@ class HooksProcessor(AbstractProcessor):
                         if hook_id and any(diffs):
                             debug(f"The hook '{hook}' config is different from what's in gitlab")
                             debug(f"Updating hook '{hook}'")
-                            changed_hook: Dict[str, Any] = project.hooks.update(
+                            updated_hook = project.hooks.update(
                                 hook_id, hook_config
                             )
-                            debug(f"Updated hook: {changed_hook}")
+                            debug(f"Updated hook: {updated_hook}")
                         elif hook_id and not any(diffs):
                             debug(f"Hook '{hook}' remains unchanged")
 

--- a/gitlabform/processors/project/hooks_processor.py
+++ b/gitlabform/processors/project/hooks_processor.py
@@ -24,52 +24,41 @@ class HooksProcessor(AbstractProcessor):
             hook_in_gitlab: RESTObject | None = next(
                 (h for h in project_hooks if h.url == hook), None
             )
+            hook_config = {"url": hook}
+            hook_config.update(configuration["hooks"][hook])
+
             hook_id = hook_in_gitlab.id if hook_in_gitlab else None
+
+            # Process hooks configured for deletion
             if configuration.get("hooks|" + hook + "|delete"):
                 if hook_id:
                     debug(f"Deleting hook '{hook}'")
                     project.hooks.delete(hook_id)
+                    debug(f"Deleted hook '{hook}'")
                 else:
                     debug(f"Not deleting hook '{hook}', because it doesn't exist")
-            else:
-                hook_config = {"url": hook}
-                hook_config.update(configuration["hooks"][hook])
-                if not hook_id:
-                    debug(f"Creating hook '{hook}'")
-                    created_hook: RESTObject = project.hooks.create(hook_config)
-                    debug(f"Created hook: {created_hook}")
-                else:
-                    if "token" in hook_config:
-                        debug(
-                            f"The hook '{hook}' config includes a token. Diff between config vs gitlab cannot be confirmed"
-                        )
-                        debug(f"Updating hook '{hook}'")
-                        updated_hook: Dict[str, Any] = project.hooks.update(
-                            hook_id, hook_config
-                        )
-                        debug(f"Updated hook: {updated_hook}")
-                    else:
-                        gl_hook: dict = (
-                            hook_in_gitlab.asdict() if hook_in_gitlab else {}
-                        )
-                        diffs = (
-                            map(
-                                lambda k: hook_config[k] != gl_hook[k],
-                                hook_config.keys(),
-                            )
-                            if gl_hook
-                            else iter(())
-                        )
-                        if hook_id and any(diffs):
-                            debug(
-                                f"The hook '{hook}' config is different from what's in gitlab"
-                            )
-                            debug(f"Updating hook '{hook}'")
-                            updated_hook = project.hooks.update(hook_id, hook_config)
-                            debug(f"Updated hook: {updated_hook}")
-                        elif hook_id and not any(diffs):
-                            debug(f"Hook '{hook}' remains unchanged")
+                continue
+            
+            # Process new hook creation
+            if not hook_id:
+                debug(f"Creating hook '{hook}'")
+                created_hook: RESTObject = project.hooks.create(hook_config)
+                debug(f"Created hook: {created_hook}")
+                continue
 
+            # Processing existing hook updates
+            gl_hook: dict = hook_in_gitlab.asdict() if hook_in_gitlab else {}
+            if self.is_hook_config_different(gl_hook, hook_config):
+                debug(f"The hook '{hook}' config is different from what's in gitlab OR it contains a token")
+                debug(f"Updating hook '{hook}'")
+                updated_hook: Dict[str, Any] = project.hooks.update(
+                    hook_id, hook_config
+                )
+                debug(f"Updated hook: {updated_hook}")
+            else:
+                debug(f"Hook '{hook}' remains unchanged")
+
+        # Process hook config enforcements
         if configuration.get("hooks|enforce"):
             for gh in project_hooks:
                 if gh.url not in hooks_in_config:
@@ -77,3 +66,40 @@ class HooksProcessor(AbstractProcessor):
                         f"Deleting hook '{gh.url}' currently setup in the project but it is not in the configuration and enforce is enabled"
                     )
                     project.hooks.delete(gh.id)
+
+    def is_hook_config_different(self, config_in_gitlab, config_in_gitlabform):
+        '''
+        Compare two dictionary representing a webhook configuration and determine
+        if they are different.
+        
+        GitLab's webhook data does not contain "token" as it is considered a secret.
+        If GitLabForm config for a webhook contains a "token", the difference cannot
+        be validated. So, an empty value for "token" is used as GitLab's webhook data,
+        which will always result in configs being different.
+
+        Args:
+            config_in_gitlab (dict): hook configuration in gitlab
+            config_in_gitlabform (dict): hook configuration in gitlabform
+        
+        Returns:
+            boolean: True if the two configs are different. Otherwise False.
+        '''
+        if "token" in config_in_gitlabform:
+            debug(
+                f"The hook '{config_in_gitlabform['url']}' config includes a token. Diff between config vs gitlab cannot be confirmed"
+            )
+            config_in_gitlab["token"] = ""
+
+        diffs = (
+            map(
+                lambda k: config_in_gitlabform[k] != config_in_gitlab[k],
+                config_in_gitlabform.keys(),
+            )
+            if config_in_gitlab
+            else iter(())
+        )
+
+        if any(diffs):
+            return True
+        else:
+            return False

--- a/gitlabform/processors/project/hooks_processor.py
+++ b/gitlabform/processors/project/hooks_processor.py
@@ -48,7 +48,7 @@ class HooksProcessor(AbstractProcessor):
 
             # Processing existing hook updates
             gl_hook: dict = hook_in_gitlab.asdict() if hook_in_gitlab else {}
-            if self.is_hook_config_different(gl_hook, hook_config):
+            if self._needs_update(gl_hook, hook_config):
                 debug(
                     f"The hook '{hook}' config is different from what's in gitlab OR it contains a token"
                 )
@@ -68,39 +68,3 @@ class HooksProcessor(AbstractProcessor):
                         f"Deleting hook '{gh.url}' currently setup in the project but it is not in the configuration and enforce is enabled"
                     )
                     project.hooks.delete(gh.id)
-
-    def is_hook_config_different(
-        self, config_in_gitlab: dict, config_in_gitlabform: dict
-    ):
-        """
-        Compare two dictionary representing a webhook configuration and determine
-        if they are different.
-
-        GitLab's webhook data does not contain "token" as it is considered a secret.
-        If GitLabForm config for a webhook contains a "token", the difference cannot
-        be validated. In this case, the config is assumed to be different. Otherwise,
-        the config data will be compared and determined if they are different.
-
-        Args:
-            config_in_gitlab (dict): hook configuration in gitlab
-            config_in_gitlabform (dict): hook configuration in gitlabform
-
-        Returns:
-            boolean: True if the two configs are different. Otherwise False.
-        """
-        if "token" in config_in_gitlabform:
-            debug(
-                f"The hook '{config_in_gitlabform['url']}' config includes a token. Diff between config vs gitlab cannot be confirmed."
-            )
-            return True
-
-        diffs = (
-            map(
-                lambda k: config_in_gitlabform[k] != config_in_gitlab[k],
-                config_in_gitlabform.keys(),
-            )
-            if config_in_gitlab
-            else iter(())
-        )
-
-        return True if any(diffs) else False

--- a/tests/acceptance/standard/test_hooks.py
+++ b/tests/acceptance/standard/test_hooks.py
@@ -27,6 +27,7 @@ class TestHooksProcessor:
               {target}:
                 hooks:
                   {first_url}:
+                    token: a1b2c3d4
                     push_events: false
                     merge_requests_events: true
                   {second_url}:
@@ -62,6 +63,7 @@ class TestHooksProcessor:
               {target}:
                 hooks:
                   {first_url}:
+                    token: a1b2c3d4
                     merge_requests_events: false
                     note_events: true
                   {second_url}:

--- a/tests/acceptance/standard/test_hooks.py
+++ b/tests/acceptance/standard/test_hooks.py
@@ -5,6 +5,7 @@ from gitlab.v4.objects import ProjectHook
 
 from tests.acceptance import run_gitlabform, get_random_name
 
+
 @pytest.fixture(scope="class")
 def urls():
     first_name = get_random_name("hook")
@@ -104,8 +105,8 @@ class TestHooksProcessor:
             assert (
                 updated_first_hook.push_events,
                 updated_first_hook.merge_requests_events,
-                updated_first_hook.note_events
-            ) == ( False, False, True )
+                updated_first_hook.note_events,
+            ) == (False, False, True)
 
             # The second hook should remain unchanged.
             # The hook did not change from the previous test case. So, updating it is not necessary.
@@ -113,8 +114,8 @@ class TestHooksProcessor:
             assert updated_second_hook.asdict() == second_hook.asdict()
             assert (
                 updated_second_hook.job_events,
-                updated_second_hook.note_events
-            ) == ( True, True )
+                updated_second_hook.note_events,
+            ) == (True, True)
 
             # The third hook should remain unchanged.
             # The hook initially had a token when it was created in previous test case.
@@ -126,7 +127,7 @@ class TestHooksProcessor:
             assert (
                 updated_third_hook.push_events,
                 updated_third_hook.merge_requests_events,
-            ) == ( True, True )
+            ) == (True, True)
 
     def test_hooks_delete(self, gl, project, urls):
         target = project.path_with_namespace

--- a/tests/acceptance/standard/test_hooks.py
+++ b/tests/acceptance/standard/test_hooks.py
@@ -76,8 +76,8 @@ class TestHooksProcessor:
         updated_second_hook = self.get_hook_from_url(project, second_url)
 
         with caplog.at_level(logging.DEBUG):
-            assert f"Changing existing hook '{first_url}'" in caplog.text
-            assert f"Hook {second_url} remains unchanged" in caplog.text
+            assert f"Updating hook '{first_url}'" in caplog.text
+            assert f"Hook '{second_url}' remains unchanged" in caplog.text
         assert updated_first_hook.asdict() != first_hook.asdict()
         assert updated_second_hook.asdict() == second_hook.asdict()
         # For the first hook, push_events stays False from previous test case when it was initially configured

--- a/tests/acceptance/standard/test_hooks.py
+++ b/tests/acceptance/standard/test_hooks.py
@@ -171,7 +171,10 @@ class TestHooksProcessor:
         # The last hook configured for deletion but it was never setup in gitlab.
         # Ensure expected error message is reported.
         with caplog.at_level(logging.DEBUG):
-            assert f"Not deleting hook '{non_existent_hook_url}', because it doesn't exist" in caplog.text
+            assert (
+                f"Not deleting hook '{non_existent_hook_url}', because it doesn't exist"
+                in caplog.text
+            )
 
     def test_hooks_enforce(self, gl, group, project, urls):
         target = project.path_with_namespace


### PR DESCRIPTION
The hooks processor was recently refactored in #635 . One of the change was to inspect and only update a hook when it is needed so that unnecessary api call/update is avoided. This was done by comparing hooks config with data from gitlab about project hooks.

The above fails when a hook config includes a `token` attribute. It's treated as secret and so it is not available in the gitlab data. The comparison fails and gitlabform produces error processing the project.

This PR fixes this issue by adding additional logic for hooks config with token. In this case an update is always done. Otherwise continue with existing logic of updating only if necessary. Updated test cases to validate it.

Fixes #685 