### PR TITLE
feat: manage job_token_scope allowlist

### DIFF
--- a/.github/workflows/pr-linter-and-tests.yml
+++ b/.github/workflows/pr-linter-and-tests.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
+      - name: Allow access to python-gitlab fork
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -62,6 +66,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
+      - name: Allow access to python-gitlab fork
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -104,6 +112,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
+      - name: Allow access to python-gitlab fork
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -143,6 +155,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
+      - name: Allow access to python-gitlab fork
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -199,6 +215,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
+      - name: Allow access to python-gitlab fork
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/dev/run_gitlab_in_docker.sh
+++ b/dev/run_gitlab_in_docker.sh
@@ -34,7 +34,7 @@ repo_root_directory="$script_directory/.."
 if [[ $# == 1 ]] ; then
   gitlab_version="$1"
 else
-  gitlab_version="latest"
+  gitlab_version="nightly"
 fi
 
 if [[ $(uname -s) == 'Darwin' ]] && [[ $(uname -m) == 'arm64' ]] ; then

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "MarkupSafe==2.1.5",
         "mergedeep==1.3.4",
         "packaging==23.2",
-        "python-gitlab==4.4.0",
+        "python-gitlab @ git+ssh://git@github.com/TimKnight-DWP/python-gitlab.git@feat/group-allowlist",
         "requests==2.31.0",
         "ruamel.yaml==0.17.21",
         "types-requests==2.31.0.20240218",


### PR DESCRIPTION
- Will use python-gitlab to manage job_token_scope
- closes #571 

Full REST api for job_token_scope allowlists expected to be released in 16.10 (Mar 21st 2023), [python-gitlab changes](https://github.com/python-gitlab/python-gitlab/pull/2816) have been tested on the `nightly` build. 

For development purposes this PR will be pointed at my fork/branch with the python-gitlab changes on