### PR TITLE
runs container as non-root

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -14,3 +14,5 @@ RUN cd gitlabform \
     && apk --purge del build-base
 
 WORKDIR /config
+
+USER 1000 # do not run as root


### PR DESCRIPTION
Runs the container as user different from root for security reasons.

See https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user