### PR TITLE
fix: error when running with --noop and --output-file parameter and config contains project to be transferred

### DIFF
--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -53,6 +53,7 @@ class GitLabForm:
         target=None,
         config_string=None,
         noop=False,
+        output_file=None,
     ):
         if target and config_string:
             # this mode is basically only for testing
@@ -65,7 +66,7 @@ class GitLabForm:
             self.start_from = 1
             self.start_from_group = 1
             self.noop = noop
-            self.output_file = None
+            self.output_file = output_file
             self.skip_version_check = True
             self.include_archived_projects = include_archived_projects
             self.just_show_version = False

--- a/gitlabform/processors/abstract_processor.py
+++ b/gitlabform/processors/abstract_processor.py
@@ -51,18 +51,18 @@ class AbstractProcessor(ABC):
                 verbose(
                     f"Processing section '{self.configuration_name}' in dry-run mode."
                 )
+                project_transfer_source = ""
                 try:
                     project_transfer_source = configuration["project"]["transfer_from"]
                     verbose(
                         f"""Project {project_or_project_and_group} is configured to be transferred, 
                         diffing config from transfer source project {project_transfer_source}."""
                     )
-                    project_or_project_and_group = project_transfer_source
                 except KeyError:
                     pass
 
                 self._print_diff(
-                    project_or_project_and_group,
+                    project_transfer_source or project_or_project_and_group,
                     configuration.get(self.configuration_name),
                 )
             else:

--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -247,7 +247,9 @@ def randomize_case(input: str) -> str:
     return "".join(random.choice((str.upper, str.lower))(char) for char in input)
 
 
-def run_gitlabform(config, target, include_archived_projects=True, noop=False):
+def run_gitlabform(
+    config, target, include_archived_projects=True, noop=False, output_file=None
+):
     # f-strings with """ used as configs have the disadvantage of having indentation in them - let's remove it here
     config = textwrap.dedent(config)
 
@@ -265,5 +267,6 @@ def run_gitlabform(config, target, include_archived_projects=True, noop=False):
         config_string=config,
         target=target,
         noop=noop,
+        output_file=output_file,
     )
     gf.run()

--- a/tests/acceptance/standard/test_running.py
+++ b/tests/acceptance/standard/test_running.py
@@ -2,6 +2,8 @@ import pytest
 from tests.acceptance import (
     run_gitlabform,
 )
+from pathlib import Path
+from ruamel.yaml import YAML
 
 
 class TestRunning:
@@ -21,6 +23,26 @@ class TestRunning:
 
         other_project = gl.projects.get(other_project.id)
         assert other_project.request_access_enabled is True
+
+    def test__ALL_output_file(self, gl, project, other_project):
+        config = f"""
+        projects_and_groups:
+          '*':
+            project_settings:
+              request_access_enabled: true
+        """
+
+        run_gitlabform(config, "ALL", output_file="output.yml")
+
+        project = gl.projects.get(project.id)
+        assert project.request_access_enabled is True
+
+        other_project = gl.projects.get(other_project.id)
+        assert other_project.request_access_enabled is True
+
+        path = Path("output.yml")
+        yaml = YAML(typ='safe')
+        assert yaml.load(path)
 
     # noinspection PyPep8Naming
     def test__ALL_dry_run(self, gl, project, other_project):

--- a/tests/acceptance/standard/test_running.py
+++ b/tests/acceptance/standard/test_running.py
@@ -41,7 +41,7 @@ class TestRunning:
         assert other_project.request_access_enabled is True
 
         path = Path("output.yml")
-        yaml = YAML(typ='safe')
+        yaml = YAML(typ="safe")
         assert yaml.load(path)
 
     # noinspection PyPep8Naming

--- a/tests/acceptance/standard/test_transfer_project.py
+++ b/tests/acceptance/standard/test_transfer_project.py
@@ -26,7 +26,9 @@ class TestTransferProject:
               description: test
         """
 
-        run_gitlabform(config, project_new_path_with_namespace, noop=True)
+        run_gitlabform(
+            config, project_new_path_with_namespace, noop=True, output_file="output.yml"
+        )
         projects_in_destination_after_transfer = other_group.projects.list()
 
         assert len(projects_in_destination_after_transfer) == len(


### PR DESCRIPTION
Fixes #728.

Update `abstract_processor.py` to not overwrite `project_or_project_and_group` when determining if a project is being transferred