### PR TITLE
fix: add improved error handling when processing transferred project

### DIFF
--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -476,8 +476,10 @@ class GitLabForm:
                 successful_projects += 1
 
             except Exception as e:
-                if "Non GET methods are not allowed for moved projects" in e.message:
-                    info("Project has been transferred, no need to process original location")
+                if "Non GET methods are not allowed for moved projects" in str(e):
+                    info(
+                        "Project has been transferred, no need to process original location"
+                    )
                     continue
 
                 failed_projects[project_number] = project_and_group

--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -476,6 +476,10 @@ class GitLabForm:
                 successful_projects += 1
 
             except Exception as e:
+                if "Non GET methods are not allowed for moved projects" in e.message:
+                    info("Project has been transferred, no need to process original location")
+                    continue
+
                 failed_projects[project_number] = project_and_group
 
                 trace = traceback.format_exc()

--- a/tests/acceptance/standard/test_transfer_project.py
+++ b/tests/acceptance/standard/test_transfer_project.py
@@ -340,6 +340,9 @@ class TestTransferProject:
 
         config = f"""
         projects_and_groups:
+          {group.path}/*:
+            project_settings:
+              description: test
           {project_new_path_with_namespace}:
             project:
               transfer_from: {project_for_function.path_with_namespace}

--- a/tests/acceptance/standard/test_transfer_project.py
+++ b/tests/acceptance/standard/test_transfer_project.py
@@ -45,6 +45,10 @@ class TestTransferProject:
 
         config = f"""
         projects_and_groups:
+          {project_for_function.path_with_namespace}/*:
+            project_settings:
+              description: test
+
           {project_new_path_with_namespace}:
             project:
               transfer_from: {project_for_function.path_with_namespace}


### PR DESCRIPTION
Gitlabform will error when it tries to process a project that has already been transferred:

```
Warning: Error occurred while processing project ... failed - expected code(s) [200], got code 405 & body: '{"message":"Non GET methods are not allowed for moved projects"}'
```

This happens when running with ALL_DEFINED target and if there's config that includes the original project path, ie.:

```
projects_and_groups:
  group/*:
    ...

  group/subgroup/*:
   ...

  group/project-a:
    project:
      transfer_from: group/subgroup/project-a
    ...
  
```

This PR add handling for this scenario.