### PR TITLE
refactor: migrate group settings processor to python-gitlab library 

### DIFF
--- a/gitlabform/gitlab/groups.py
+++ b/gitlabform/gitlab/groups.py
@@ -97,20 +97,3 @@ class GitLabGroups(GitLabCore):
                 project_and_groups_in_group_namespace,
                 key=lambda x: x["path_with_namespace"],
             )
-
-    def get_group_settings(self, project_and_group_name):
-        try:
-            return self._make_requests_to_api("groups/%s", project_and_group_name)
-        except NotFoundException:
-            return dict()
-
-    def put_group_settings(self, project_and_group_name, group_settings):
-        # group_settings has to be like this:
-        # {
-        #     'setting1': value1,
-        #     'setting2': value2,
-        # }
-        # ..as documented at: https://docs.gitlab.com/ee/api/groups.html#update-group
-        self._make_requests_to_api(
-            "groups/%s", project_and_group_name, "PUT", group_settings
-        )

--- a/gitlabform/processors/group/group_settings_processor.py
+++ b/gitlabform/processors/group/group_settings_processor.py
@@ -1,12 +1,30 @@
+from logging import info, debug
+from typing import Dict
+
 from gitlabform.gitlab import GitLab
-from gitlabform.processors.single_entity_processor import SingleEntityProcessor
+from gitlab.v4.objects.groups import Group
+from gitlabform.processors.abstract_processor import AbstractProcessor
 
 
-class GroupSettingsProcessor(SingleEntityProcessor):
+class GroupSettingsProcessor(AbstractProcessor):
     def __init__(self, gitlab: GitLab):
-        super().__init__(
-            "group_settings",
-            gitlab,
-            get_method_name="get_group_settings",
-            edit_method_name="put_group_settings",
-        )
+        super().__init__("group_settings", gitlab)
+
+    def _process_configuration(self, group: str, configuration: Dict):
+        configured_group_settings = configuration.get("group_settings", {})
+
+        gitlab_group: Group = self.gl.get_group_by_path_cached(group)
+
+        if self._needs_update(gitlab_group.asdict(), configured_group_settings):
+            info(f"Updating group settings for group {gitlab_group.name}")
+            self.update_group_settings(gitlab_group, configured_group_settings)
+        else:
+            debug("No update needed for Group Settings")
+
+    @staticmethod
+    def update_group_settings(gitlab_group: Group, group_settings_config: dict):
+        for key in group_settings_config:
+            value = group_settings_config[key]
+            debug(f"Updating setting {key} to value {value}")
+            gitlab_group.__setattr__(key, value)
+            gitlab_group.save()


### PR DESCRIPTION
Use python gitlab lib for group settings. 

Ran existing acceptance tests in standard folder and they pass. 