### PR TITLE
test: update pipeline_schedules tests for GitLab 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@
 
 Please see <a href="https://gitlabform.github.io/gitlabform/">the project site</a> for more information.
 
-GitLabForm is built and tested against [`gitlab-ee/16.11.2-ee.0`](https://hub.docker.com/r/gitlab/gitlab-ee/tags), we have not yet patched and verified changes for [GitLab 17.0](https://about.gitlab.com/releases/2024/05/16/gitlab-17-0-released/)
+GitLabForm is built and tested against [`gitlab-ee/latest`](https://hub.docker.com/r/gitlab/gitlab-ee/tags).

--- a/dev/run_gitlab_in_docker.sh
+++ b/dev/run_gitlab_in_docker.sh
@@ -34,7 +34,7 @@ repo_root_directory="$script_directory/.."
 if [[ $# == 1 ]] ; then
   gitlab_version="$1"
 else
-  gitlab_version="16.11.2-ee.0"
+  gitlab_version="latest"
 fi
 
 if [[ $(uname -s) == 'Darwin' ]] && [[ $(uname -m) == 'arm64' ]] ; then

--- a/docs/reference/pipeline_schedules.md
+++ b/docs/reference/pipeline_schedules.md
@@ -17,6 +17,14 @@ There are 2 gitlabform specific keys/configs that can be set under `schedules` o
 - `delete` - set this to `true` under a specific schedule to delete that particular schedule.
 - `enforce` - set this to `true` under `schedules` so that any schedules that are not in `schedules` section are deleted.
 
+!!! warning
+
+    * Both a short version of a ref (e.g "main") and full version (e.g. "refs/heads/main") is accepted, GitLab will automatically expand short refs into full refs.
+
+    * If the short ref is ambigious it will be rejected: https://docs.gitlab.com/ee/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+
+    * This appears to be more stringently enforced within GitLab 17.x
+
 
 Example 1:
 ```yaml

--- a/tests/acceptance/standard/test_schedules.py
+++ b/tests/acceptance/standard/test_schedules.py
@@ -65,7 +65,9 @@ class TestSchedules:
         )
         assert schedule is not None
         assert schedule.description == "New schedule"
-        assert schedule.ref == "main"
+        # If the Short Version is provided, the Full Version is returned:
+        # https://docs.gitlab.com/ee/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+        assert schedule.ref == "refs/heads/main"
         assert schedule.cron == "0 * * * *"
         assert schedule.cron_timezone == "London"
         assert schedule.active is True
@@ -87,7 +89,7 @@ class TestSchedules:
         )
         assert schedule is not None
         assert schedule.description == "New schedule with mandatory fields"
-        assert schedule.ref == "main"
+        assert schedule.ref == "refs/heads/main"
         assert schedule.cron == "30 1 * * *"
         assert schedule.cron_timezone == "UTC"
         assert schedule.active is True
@@ -115,7 +117,7 @@ class TestSchedules:
         )
         assert schedule is not None
         assert schedule.description == "New schedule with variables"
-        assert schedule.ref == "main"
+        assert schedule.ref == "refs/heads/main"
         assert schedule.cron == "30 1 * * *"
         assert schedule.cron_timezone == "UTC"
         assert schedule.active is True
@@ -160,7 +162,7 @@ class TestSchedules:
         assert schedule.description == existing_schedule.description
 
         # Verify updates to schedule
-        assert schedule.ref == "scheduled/new-feature"
+        assert schedule.ref == "refs/heads/scheduled/new-feature"
         assert schedule.cron == "0 */4 * * *"
         assert schedule.cron_timezone == "Stockholm"
         assert schedule.active is False
@@ -199,7 +201,7 @@ class TestSchedules:
         assert schedule.description == existing_schedule.description
 
         # Verify schedule
-        assert schedule.ref == "main"
+        assert schedule.ref == "refs/heads/main"
         assert schedule.cron == "0 * * * *"
         assert schedule.active is True
 
@@ -209,7 +211,9 @@ class TestSchedules:
             in caplog.text
         )
 
-    def test__update_existing_schedule_with_variables(self, project_for_function):
+    def test__apply_existing_schedule_with_variables_to_new_branch(
+        self, project_for_function, branch_for_function
+    ):
         existing_schedule = project_for_function.pipelineschedules.create(
             {
                 "description": "Existing schedule with vars",
@@ -227,7 +231,7 @@ class TestSchedules:
           {project_for_function.path_with_namespace}:
             schedules:
               "Existing schedule with vars":
-                ref: scheduled/new-feature
+                ref: {branch_for_function}
                 cron: "0 */4 * * *"
                 cron_timezone: "Stockholm"
                 active: false
@@ -254,7 +258,7 @@ class TestSchedules:
         assert variable.get("key") == "existing_var"
         assert variable.get("value") == "new_value"
 
-        assert schedule.ref == "scheduled/new-feature"
+        assert schedule.ref == f"refs/heads/{branch_for_function}"
         assert schedule.cron == "0 */4 * * *"
         assert schedule.cron_timezone == "Stockholm"
         assert schedule.active is False
@@ -281,7 +285,7 @@ class TestSchedules:
 
         schedule = existing_schedules[0]
         assert schedule.description == "Existing schedule to replace"
-        assert schedule.ref == "scheduled/new-feature"
+        assert schedule.ref == "refs/heads/scheduled/new-feature"
         assert schedule.cron == "0 */3 * * *"
         assert schedule.cron_timezone == "London"
         assert schedule.active is True
@@ -326,7 +330,7 @@ class TestSchedules:
         assert len(schedules_after) == 1
         assert schedule is not None
         assert schedule.description == "New schedule to test enforce config"
-        assert schedule.ref == "main"
+        assert schedule.ref == "refs/heads/main"
         assert schedule.cron == "30 1 * * *"
         assert schedule.cron_timezone == "UTC"
         assert schedule.active is True
@@ -368,14 +372,14 @@ class TestSchedules:
 
         assert schedule1 is not None
         assert schedule1.description == "New schedule to test enforce config"
-        assert schedule1.ref == "main"
+        assert schedule1.ref == "refs/heads/main"
         assert schedule1.cron == "30 1 * * *"
         assert schedule1.cron_timezone == "UTC"
         assert schedule1.active is True
 
         assert schedule2 is not None
         assert schedule2.description == "New schedule with variables"
-        assert schedule2.ref == "main"
+        assert schedule2.ref == "refs/heads/main"
         assert schedule2.cron == "30 1 * * *"
         assert schedule2.cron_timezone == "UTC"
         assert schedule2.active is True


### PR DESCRIPTION
- Tests required to be updated due to enforcement fixes in GL 17
- Documentation updated; pre-existing rules on GL API are now being enforced correctly
- relates to #764 