### PR TITLE
docs: Add info about and link to pyenv

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,5 +1,6 @@
 # Requirements
 
 * Docker or Python 3.8-3.12
+    * you can use [pyenv](https://github.com/pyenv/pyenv) if your OS does not have a required Python version
 * Self-Hosted GitLab 14.4+ or SaaS GitLab @ gitlab.com
     * Premium (paid) license for some features


### PR DESCRIPTION
Minor update about ability to use pyenv if one's OS does not have a required version of Python.