### PR TITLE
fix: path for member_roles in saas

### DIFF
--- a/gitlabform/gitlab/python_gitlab.py
+++ b/gitlabform/gitlab/python_gitlab.py
@@ -64,7 +64,7 @@ class PythonGitlab(Gitlab):
         if self.is_gitlab_saas():
             if group_id is None:
                 raise GitlabGetError(
-                    f"Group Id must be provided when getting member roles on GitLab SaaS",
+                    "Group Id must be provided when getting member roles on GitLab SaaS",
                     404,
                 )
             # SAAS

--- a/gitlabform/gitlab/python_gitlab.py
+++ b/gitlabform/gitlab/python_gitlab.py
@@ -1,9 +1,11 @@
 import functools
 from typing import Union
 
+from cli_ui import debug
+
 import gitlab.const
 from gitlab import Gitlab, GitlabGetError
-from gitlab.base import RESTObject, RESTObjectList
+from gitlab.base import RESTObject
 from gitlab.v4.objects import Group, Project
 
 
@@ -66,11 +68,12 @@ class PythonGitlab(Gitlab):
                     404,
                 )
             # SAAS
-            path = f"groups/{group_id}/member_roles"
+            path = f"/groups/{group_id}/member_roles"
         else:
             # Self-Managed & Dedicated
             path = f"/member_roles"
 
+        debug(f"Retrieving member roles from: {path}")
         return self.http_get(path)
 
     @functools.lru_cache()

--- a/tests/unit/gitlab/test_python_gitlab.py
+++ b/tests/unit/gitlab/test_python_gitlab.py
@@ -1,0 +1,53 @@
+import pytest
+from gitlab import GitlabGetError
+
+from gitlabform.gitlab.python_gitlab import PythonGitlab
+from unittest.mock import MagicMock
+
+
+class TestPythonGitlab:
+
+    def test_get_member_roles_cached_uses_correct_path_for_saas(self):
+        group_id = 2
+        python_gitlab = PythonGitlab()
+        # Don't make a real HTTP call
+        python_gitlab.http_get = MagicMock(return_value=None)
+
+        # Return we are in GitLab SaaS
+        python_gitlab.is_gitlab_saas = MagicMock(return_value=True)
+
+        python_gitlab.get_member_roles_cached(group_id)
+
+        python_gitlab.http_get.assert_called_with(f"/groups/{group_id}/member_roles")
+
+    def test_get_member_roles_cached_throws_404_error_when_invoked_on_saas_without_group_id(
+        self,
+    ):
+        python_gitlab = PythonGitlab()
+        # Don't make a real HTTP call
+        python_gitlab.http_get = MagicMock(return_value=None)
+
+        # Return we are in GitLab SaaS
+        python_gitlab.is_gitlab_saas = MagicMock(return_value=True)
+
+        with pytest.raises(GitlabGetError) as exception:
+            python_gitlab.get_member_roles_cached(None)
+
+        assert exception.value.error_message is not None
+        assert exception.value.response_code == 404
+        python_gitlab.http_get.assert_not_called()
+
+    def test_get_member_roles_cached_uses_correct_path_for_self_managed_and_dedicated(
+        self,
+    ):
+        group_id = 2
+        python_gitlab = PythonGitlab()
+        # Don't make a real HTTP call
+        python_gitlab.http_get = MagicMock(return_value=None)
+
+        # Return we are not in GitLab SaaS
+        python_gitlab.is_gitlab_saas = MagicMock(return_value=False)
+
+        python_gitlab.get_member_roles_cached(group_id)
+
+        python_gitlab.http_get.assert_called_with(f"/member_roles")


### PR DESCRIPTION
- can't be tested by our test suite as standing up a container counts as self-managed not saas