### PR TITLE
chore!: stop supporting Python older than 3.12 

### DIFF
--- a/.github/workflows/tests-standard.yml
+++ b/.github/workflows/tests-standard.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.12]
       fail-fast : false
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.12]
       fail-fast : false
     steps:
       - uses: actions/checkout@v4
@@ -103,7 +103,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.12]
       fail-fast : false
     steps:
       - uses: actions/checkout@v4

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,6 +1,6 @@
 # Requirements
 
-* Docker or Python 3.8-3.12
-    * you can use [pyenv](https://github.com/pyenv/pyenv) if your OS does not have a required Python version
+* Python 3.12
+    * you can use Docker image or [pyenv](https://github.com/pyenv/pyenv) if your OS does not have a required Python version
 * Self-Hosted GitLab 14.4+ or SaaS GitLab @ gitlab.com
     * Premium (paid) license for some features

--- a/gitlabform/processors/util/labels_processor.py
+++ b/gitlabform/processors/util/labels_processor.py
@@ -1,5 +1,5 @@
 from logging import debug, info
-from typing import Dict, List, Callable, Union
+from typing import Dict, List, Callable
 
 from gitlab.base import RESTObject
 from gitlab.v4.objects import Group, Project, ProjectLabel, GroupLabel
@@ -12,9 +12,7 @@ class LabelsProcessor:
         self,
         configured_labels: Dict,
         enforce: bool,
-        group_or_project: Union[
-            Group, Project
-        ],  # Group | Project -> |: operand not supported in 3.8/3.9
+        group_or_project: Group | Project,
         needs_update: Callable,  # self._needs_update passed from AbstractProcessor called process_labels
     ):
         # python-gitlab/python-gitlab#2843
@@ -61,7 +59,7 @@ class LabelsProcessor:
     @staticmethod
     def update_existing_label(
         configured_label,
-        full_label: Union[GroupLabel, ProjectLabel],  # GroupLabel | ProjectLabel
+        full_label: GroupLabel | ProjectLabel,
         parent_object_type: str,
     ):
         info(f"Updating {full_label.name} on {parent_object_type}")
@@ -75,7 +73,7 @@ class LabelsProcessor:
     @staticmethod
     def create_new_label(
         configured_labels,
-        group_or_project: Union[Group, Project],  # Group | Project
+        group_or_project: Group | Project,
         label_name: str,
         parent_object_type: str,
     ):

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,6 @@ setup(
     author="Greg Dubicki and Contributors",
     keywords=["cli", "yaml", "gitlab", "configuration-as-code"],
     classifiers=[
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Information Technology",
@@ -42,7 +38,7 @@ setup(
     packages=find_packages(),
     package_data={"": ["LICENSE", "version", "*.md", "config.yml"]},
     include_package_data=True,
-    python_requires=">=3.8.0",
+    python_requires=">=3.12.0",
     install_requires=[
         "certifi==2024.8.30",
         "cli-ui==0.17.2",


### PR DESCRIPTION
BREAKING CHANGE: but note that the next older Python
version support drop (when 3.13 stable will be released)
will NOT be treated as a breaking change anymore.

https://github.com/gitlabform/gitlabform/issues/754