### PR TITLE
feat: enhanced cron expressions

### DIFF
--- a/docs/reference/pipeline_schedules.md
+++ b/docs/reference/pipeline_schedules.md
@@ -61,3 +61,25 @@ projects_and_groups:
         cron_timezone: "London"
         active: false
 ```
+
+!!! info
+
+* There is an additional, extended syntax available for distributing pipelines automatically to avoid a pipeline stampede, see the [open issue at GitLab](https://gitlab.com/gitlab-org/gitlab/-/issues/17799) for some details.
+* For **minutes**, **hours** and **weekdays** the uppercase letter ˚H will be replaced with stable, project specific values in the range of `0-59`, `0-23` resp `0-6`.
+* There is a syntax for restricting the range: `H(15-20)` will return a value between 15 and 20.
+* An interval like `H/20` e.g. in the minute column will firstly determine a value between 0 and 19 and then add corresponding entries to fill the as well, i.e. might give you `14,34,54` for the minutes. 
+* This allows you to specify something like `H H(1-7) * * *` once as expression and each project will nonetheless get a different value for minute and hour, so your pipelines are distributed between 01:00 and 07:59 in above example.
+
+Examples:
+* Project with id 1: `H H * * *` -> `8 18 * * *`
+* Project with id 3: `H H * * *` -> `15 18 * * *`
+* Project with id 3: `H(15-20),H(45-50) H(1-7) * * *` -> `16,49 5 * * *`
+* Project with id 4: `H H * * *` -> `15 9 * * *`
+
+There are four (caseinsensitive) _aliases_ for ease of use similar to what exists in Jenkins:
+* `@hourly` -> `H * * * *`
+* `@daily` -> `H H * * *`
+* `@weekly` -> `H H * * H`
+* `@nightly` -> `H H(00-06) * * *`
+
+

--- a/gitlabform/processors/project/schedules_processor.py
+++ b/gitlabform/processors/project/schedules_processor.py
@@ -1,3 +1,5 @@
+import random
+import re
 from logging import debug
 from typing import Dict, List
 
@@ -82,7 +84,9 @@ class SchedulesProcessor(AbstractProcessor):
         schedule_in_gitlab: ProjectPipelineSchedule,
         schedule_description: str,
     ):
-
+        entity_config["cron"] = _replace_extended_cron_pattern(
+            project.id, entity_config["cron"]
+        )
         if self._needs_update(schedule_in_gitlab.asdict(), entity_config):
             debug("Changing existing pipeline schedule '%s'", schedule_description)
             # In order to edit a Schedule created by someone else we need to take ownership:
@@ -110,7 +114,9 @@ class SchedulesProcessor(AbstractProcessor):
     ):
         schedule_data = {"description": schedule_description, **entity_config}
         debug("Creating pipeline schedule using data: '%s'", schedule_data)
-
+        entity_config["cron"] = _replace_extended_cron_pattern(
+            project.id, entity_config["cron"]
+        )
         created_schedule_id = project.pipelineschedules.create(schedule_data).id
         created_schedule = project.pipelineschedules.get(created_schedule_id)
 
@@ -168,3 +174,63 @@ class SchedulesProcessor(AbstractProcessor):
                     schedule_description,
                 )
                 project.pipelineschedules.get(schedule_id).delete()
+
+
+class ExtendedCronPattern:
+
+    def __init__(self, project_id: int, cron_expression: str):
+        self._h_pattern = re.compile(
+            r"H(?:(\((?P<start>\d+)-(?P<end>\d+)\))|(?P<interval>/\d+))?"
+        )
+        # We do use random here to achieve a stable pseudo-random value, this is not security relevant
+        # Seeding with project_id always returns the same numbers, that is what we want here.
+        self._random = random.Random()  # nosec B311
+        self._random.seed(project_id, 2)
+        self._cron_parts = cron_expression.split()
+        if len(self._cron_parts) != 5:
+            raise ValueError(
+                f"Expected 5 parts in the cron expression, got {self._cron_parts}"
+            )
+
+    def render(self) -> str:
+        self._cron_parts[0] = self._detect_and_replace_h(self._cron_parts[0], 60)
+        self._cron_parts[1] = self._detect_and_replace_h(self._cron_parts[1], 24)
+        self._cron_parts[4] = self._detect_and_replace_h(self._cron_parts[4], 7)
+        return " ".join(self._cron_parts)
+
+    def _detect_and_replace_h(self, cron_part: str, default_max: int):
+        parts = cron_part.split(",")
+        for i, _ in enumerate(parts):
+            match = self._h_pattern.match(parts[i])
+            if match:
+                self._replace_h(i, parts, match, default_max)
+        return ",".join(parts)
+
+    def _replace_h(self, i: int, parts: List[str], match: re.Match, default_max: int):
+        interval = match.group("interval") or ""
+        if interval:
+            interval = int(interval[1:])
+            times = int((default_max) / int(interval))
+            first = self._random.randint(0, interval)
+            result = [str(first)]
+            result.extend(str(first + i * interval) for i in range(1, times))
+        else:
+            start = int(match.group("start") or 0)
+            end = int(match.group("end") or default_max - 1)
+            result = [str(self._random.randint(start, end))]
+        parts[i] = parts[i].replace(match.string, ",".join(result))
+
+
+EXTENDED_CRON_PATTERN_ALIASES = {
+    "@hourly": "H * * * *",
+    "@daily": "H H * * *",
+    "@weekly": "H H * * H",
+    "@nightly": "H H(00-06) * * *",
+}
+
+
+def _replace_extended_cron_pattern(project_id: int, cron_expression: str) -> str:
+    cron_expression = EXTENDED_CRON_PATTERN_ALIASES.get(
+        cron_expression.lower(), cron_expression
+    )
+    return ExtendedCronPattern(project_id, cron_expression).render()

--- a/tests/unit/processors/test_schedules_processor_extended_cron_pattern.py
+++ b/tests/unit/processors/test_schedules_processor_extended_cron_pattern.py
@@ -1,0 +1,41 @@
+import pytest
+
+from gitlabform.processors.project import schedules_processor
+
+
+@pytest.mark.parametrize(
+    ("project_id", "cron", "expected"),
+    [
+        (1, "* * * * *", "* * * * *"),
+        (1, "@HOURLY", "8 * * * *"),
+        (1, "H * * * *", "8 * * * *"),
+        (1, "@daily", "8 18 * * *"),
+        (1, "H H * * *", "8 18 * * *"),
+        (1, "@weekly", "8 18 * * 6"),
+        (1, "H H * * H", "8 18 * * 6"),
+        (1, "@nightly", "8 4 * * *"),
+        (2, "H * * * *", "55 * * * *"),
+        (2, "H H * * *", "55 1 * * *"),
+        (3, "H * * * *", "15 * * * *"),
+        (3, "H H * * *", "15 18 * * *"),
+        (3, "H(10-14) H * * *", "11 18 * * *"),
+        (3, "H(15-20),H(45-50)  H(1-7) * *       *", "16,49 5 * * *"),
+        (3, "H(15-20),H(45-50)  H(01-07) * * MON-FRI", "16,49 5 * * MON-FRI"),
+        (4, "H H * * *", "15 9 * * *"),
+        (5, "*/10 01-07,20-23 * * *", "*/10 01-07,20-23 * * *"),
+        (5, "H/15 */4 * * *", "8,23,38,53 */4 * * *"),
+        (5, "H/20 H/4,H * * *", "19,39,59 2,6,10,14,18,22,23 * * *"),
+    ],
+)
+def test_cron_expressions(project_id, cron, expected):
+    assert (
+        schedules_processor._replace_extended_cron_pattern(project_id, cron) == expected
+    )
+
+
+def test_invalid_cron_expression():
+    with pytest.raises(ValueError) as exc_info:
+        schedules_processor.ExtendedCronPattern(1, "* * *")
+    assert str(exc_info.value) == str(
+        ValueError("Expected 5 parts in the cron expression, got ['*', '*', '*']")
+    )


### PR DESCRIPTION
* Allow an extended syntax for minutes, hours and weekdays in definitions.
* Replace `H(N1-N2)` for minutes and hours with a project stable number between N1 and N2 including both values.
* Specifying letter `H` only is the same as `H(0-59)` for minutes, `H(0-23)` for hours and H(0-6)' for weedays.
* This allows to specify one single cron expression which may be reused in all projects of a group.
* Add some common aliases like '@nightly' etc.

Refs: #455