### PR TITLE
docs: add new feature docs to navigation of docs about various configuration options

### DIFF
--- a/docs/contrib/local_development.md
+++ b/docs/contrib/local_development.md
@@ -100,7 +100,7 @@ To run only a single class with tests run f.e. `py.test tests/acceptance -k "Tes
 To make mkdocs build the app website and serve it on your loopback interface do this:
 ```shell
 . venv/bin/activate
-pip install -e .[docs]
+pip install -e '.[docs]'
 mkdocs serve
 ```
 ...and open the provided link (probably [http://127.0.0.1:8000/](http://127.0.0.1:8000/)) in your browser.

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,40 +3,41 @@
 GitLabForm enables you to manage the [(GitLab's) Application Settings](reference/settings.md#application-settings) and:
 
 * Group:
-    * [Badges](reference/badges.md#group-badges),
-    * [Members (users) {add/remove user, change access level, optional enforce}](reference/members.md#group-members),
-    * [Members (groups) {share/unshare with group, change access level, optional enforce}](reference/members.md#group-members),
-    * [Members using LDAP Group Links](reference/group_ldap_links.md) (**GitLab Premium (paid) only**),
-    * [CI/CD variables](reference/ci_cd_variables.md#group-cicd-variables),
-    * [Settings](reference/settings.md#group-settings),
-    * [Members using SAML Group Links](reference/group_saml_links.md) (**GitLab Premium (paid) only**),
+    * [Badges](reference/badges.md#group-badges)
+    * [Members (users) {add/remove user, change access level, optional enforce}](reference/members.md#group-members)
+    * [Members (groups) {share/unshare with group, change access level, optional enforce}](reference/members.md#group-members)
+    * [Members using LDAP Group Links](reference/group_ldap_links.md) (**GitLab Premium (paid) only**)
+    * [CI/CD variables](reference/ci_cd_variables.md#group-cicd-variables)
+    * [Settings](reference/settings.md#group-settings)
+    * [Members using SAML Group Links](reference/group_saml_links.md) (**GitLab Premium (paid) only**)
 
 * Project:
-    * [Archive/unarchive](reference/archive_unarchive.md),
+    * [Archive/unarchive](reference/archive_unarchive.md)
     * [Badges](reference/badges.md#project-badges)
-    * [CI/CD variables](reference/ci_cd_variables.md#project-cicd-variables),
+    * [CI/CD variables](reference/ci_cd_variables.md#project-cicd-variables)
+    * [CI/CD Job Token Scope](reference/job_token_scope.md)
     * [Protected branches](reference/protected_branches.md):
         * access levels (roles) allowed to push/merge/unprotect, allow force push flag,
         * users/groups allowed to push/merge/unprotect, code owner approval required flag (**GitLab Premium (paid) only**),
-    * [Protected environments](reference/protected_environments.md),
-    * [Deploy keys](reference/deploy_keys.md),
-    * [Files {add, edit or delete}, with templating based on Jinja2 (now supports custom variables!)](reference/files.md),
-    * [Webhooks](reference/webhooks.md),
-    * [Members (users) {add/remove user, change access level, optional enforce}](reference/members.md#project-members),
-    * [Members (groups) {share/unshare with group, change access level, optional enforce}](reference/members.md#project-members),
-    * [Merge Requests project-level configuration and approval rules](reference/merge_requests.md) (**GitLab Premium (paid) only**),
-    * [Pipeline schedules](reference/pipeline_schedules.md),
-    * [Push Rules](reference/push_rules.md) (**GitLab Premium (paid) only**),
-    * [Integrations](reference/integrations.md),
-    * [Settings](reference/settings.md#project-settings),
-    * [Tags protect/unprotect](reference/tags_protection.md),
-    * [Resource groups](reference/resource_groups.md),
+    * [Protected environments](reference/protected_environments.md)
+    * [Deploy keys](reference/deploy_keys.md)
+    * [Files {add, edit or delete}, with templating based on Jinja2 (now supports custom variables!)](reference/files.md)
+    * [Webhooks](reference/webhooks.md)
+    * [Members (users) {add/remove user, change access level, optional enforce}](reference/members.md#project-members)
+    * [Members (groups) {share/unshare with group, change access level, optional enforce}](reference/members.md#project-members)
+    * [Merge Requests project-level configuration and approval rules](reference/merge_requests.md) (**GitLab Premium (paid) only**)
+    * [Pipeline schedules](reference/pipeline_schedules.md)
+    * [Push Rules](reference/push_rules.md) (**GitLab Premium (paid) only**)
+    * [Integrations](reference/integrations.md)
+    * [Settings](reference/settings.md#project-settings)
+    * [Tags protect/unprotect](reference/tags_protection.md)
+    * [Resource groups](reference/resource_groups.md)
     * [CI/CD Job Token Scope](reference/job_token_scope.md)
 
 ...for:
 
-* all projects in your GitLab instance/that you have access to,
-* a group/subgroup of projects,
-* a single project,
+* all projects in your GitLab instance/that you have access to
+* a group/subgroup of projects
+* a single project
 
 ...and a combination of them.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ is a specialized configuration as a code tool for GitLab:
 
 ### Short and powerful syntax
 
-A lot of features with a little amount of YAML thanks to the [hierarchical configuration with inheritance, merging/overwriting and additivity](reference/#effective-configuration) .
+A lot of features with a little amount of YAML thanks to the [hierarchical configuration with inheritance, merging/overwriting and additivity](reference/index.md#effective-configuration) .
 ```yaml
 projects_and_groups:
   # configuration shared by all projects in a group named 'a_group'...
@@ -37,7 +37,7 @@ projects_and_groups:
 
 ### Dynamic features
 
-GitLab introduces new features monthly. You can often use them in GitLabForm without upgrading the app because we [pass some parameters as-is to GitLab APIs with PUT/POST requests](reference/#raw-parameters-passing).
+GitLab introduces new features monthly. You can often use them in GitLabForm without upgrading the app because we [pass some parameters as-is to GitLab APIs with PUT/POST requests](reference/index.md#raw-parameters-passing).
 ```yaml
 projects_and_groups:
   a_group/a_project:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,9 +14,11 @@ nav:
       - Badges: reference/badges.md
       - Branches: reference/protected_branches.md
       - CI/CD Variables: reference/ci_cd_variables.md
+      - CI/CD Job Token Scope: reference/job_token_scope.md
       - Deploy Keys: reference/deploy_keys.md
       - Files: reference/files.md
       - Group LDAP links: reference/group_ldap_links.md
+      - Group SAML links: reference/group_saml_links.md
       - Integrations: reference/integrations.md
       - Labels: reference/labels.md
       - Members: reference/members.md


### PR DESCRIPTION
Couple of new features released in recent versions were not available in the navigation menu used for browsing various feature specific configuration options. This PR adds those docs to the nav list. Also added some minor chores/fixes to the docs.

closes #782 
