### PR TITLE
Adding flag to only print settings that are being changed

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -24,6 +24,17 @@ To apply settings for all groups and projects that you can modify, run:
 gitlabform ALL
 ```
 
+To see what changes are being made, run:
+
+```shell
+gitlabform ALL_DEFINED --verbose
+```
+
+To see what changes are being made but limit the output to only those settings that are changing, run:
+
+```shell
+gitlabform -c config.yml ALL_DEFINED --verbose --diff-only-changed
+```
 
 Run:
 

--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -67,6 +67,7 @@ class GitLabForm:
             self.start_from = 1
             self.start_from_group = 1
             self.noop = noop
+            self.diff_only_changed = False
             self.output_file = output_file
             self.skip_version_check = True
             self.include_archived_projects = include_archived_projects
@@ -87,6 +88,7 @@ class GitLabForm:
                 self.start_from,
                 self.start_from_group,
                 self.noop,
+                self.diff_only_changed,
                 self.output_file,
                 self.skip_version_check,
                 self.include_archived_projects,
@@ -214,6 +216,14 @@ class GitLabForm:
         )
 
         parser.add_argument(
+            "-doc",
+            "--diff-only-changed",
+            dest="diff_only_changed",
+            action="store_true",
+            help="only show items who's values are changing in the diff."
+        )
+
+        parser.add_argument(
             "-o",
             "--output-file",
             dest="output_file",
@@ -284,6 +294,7 @@ class GitLabForm:
             args.start_from,
             args.start_from_group,
             args.noop,
+            args.diff_only_changed,
             args.output_file,
             args.skip_version_check,
             args.include_archived_projects,
@@ -384,6 +395,7 @@ class GitLabForm:
                 "",
                 application_configuration,
                 dry_run=self.noop,
+                diff_only_changed=self.diff_only_changed,
                 effective_configuration=effective_configuration,
                 only_sections=self.only_sections,
             )
@@ -420,6 +432,7 @@ class GitLabForm:
                     group,
                     group_configuration,
                     dry_run=self.noop,
+                    diff_only_changed=self.diff_only_changed,
                     effective_configuration=effective_configuration,
                     only_sections=self.only_sections,
                 )
@@ -483,6 +496,7 @@ class GitLabForm:
                     project_and_group,
                     project_configuration,
                     dry_run=self.noop,
+                    diff_only_changed=self.diff_only_changed,
                     effective_configuration=effective_configuration,
                     only_sections=self.only_sections,
                 )

--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -220,7 +220,7 @@ class GitLabForm:
             "--diff-only-changed",
             dest="diff_only_changed",
             action="store_true",
-            help="only show items who's values are changing in the diff."
+            help="only show items who's values are changing in the diff.",
         )
 
         parser.add_argument(

--- a/gitlabform/processors/__init__.py
+++ b/gitlabform/processors/__init__.py
@@ -23,13 +23,14 @@ class AbstractProcessors(ABC):
         entity_reference: str,
         configuration: dict,
         dry_run: bool,
+        diff_only_changed: bool,
         effective_configuration: EffectiveConfigurationFile,
         only_sections: List[str],
     ):
         for processor in self.processors:
             if only_sections == "all" or processor.configuration_name in only_sections:
                 processor.process(
-                    entity_reference, configuration, dry_run, effective_configuration
+                    entity_reference, configuration, dry_run, diff_only_changed, effective_configuration
                 )
             else:
                 verbose(

--- a/gitlabform/processors/__init__.py
+++ b/gitlabform/processors/__init__.py
@@ -30,7 +30,11 @@ class AbstractProcessors(ABC):
         for processor in self.processors:
             if only_sections == "all" or processor.configuration_name in only_sections:
                 processor.process(
-                    entity_reference, configuration, dry_run, diff_only_changed, effective_configuration
+                    entity_reference,
+                    configuration,
+                    dry_run,
+                    diff_only_changed,
+                    effective_configuration,
                 )
             else:
                 verbose(

--- a/gitlabform/processors/abstract_processor.py
+++ b/gitlabform/processors/abstract_processor.py
@@ -29,6 +29,7 @@ class AbstractProcessor(ABC):
         project_or_project_and_group: str,
         configuration,
         dry_run: bool,
+        diff_only_changed: bool,
         effective_configuration: EffectiveConfigurationFile,
     ):
         if self._section_is_in_config(configuration):
@@ -63,6 +64,7 @@ class AbstractProcessor(ABC):
                 self._print_diff(
                     project_transfer_source or project_or_project_and_group,
                     configuration.get(self.configuration_name),
+                    diff_only_changed=diff_only_changed,
                 )
             else:
                 verbose(f"Processing section '{self.configuration_name}'")
@@ -142,7 +144,7 @@ class AbstractProcessor(ABC):
     ):
         pass
 
-    def _print_diff(self, project_or_project_and_group: str, entity_config):
+    def _print_diff(self, project_or_project_and_group: str, entity_config, diff_only_changed: bool):
         verbose(f"Diffing for section '{self.configuration_name}' is not supported yet")
 
     def _needs_update(

--- a/gitlabform/processors/abstract_processor.py
+++ b/gitlabform/processors/abstract_processor.py
@@ -144,7 +144,9 @@ class AbstractProcessor(ABC):
     ):
         pass
 
-    def _print_diff(self, project_or_project_and_group: str, entity_config, diff_only_changed: bool):
+    def _print_diff(
+        self, project_or_project_and_group: str, entity_config, diff_only_changed: bool
+    ):
         verbose(f"Diffing for section '{self.configuration_name}' is not supported yet")
 
     def _needs_update(

--- a/gitlabform/processors/project/variables_processor.py
+++ b/gitlabform/processors/project/variables_processor.py
@@ -36,7 +36,9 @@ class VariablesProcessor(MultipleEntitiesProcessor):
         else:
             return True
 
-    def _print_diff(self, project_and_group: str, configuration, only_changed: bool = False):
+    def _print_diff(
+        self, project_and_group: str, configuration, only_changed: bool = False
+    ):
         try:
             current_variables = self.gitlab.get_variables(project_and_group)
 

--- a/gitlabform/processors/project/variables_processor.py
+++ b/gitlabform/processors/project/variables_processor.py
@@ -36,7 +36,7 @@ class VariablesProcessor(MultipleEntitiesProcessor):
         else:
             return True
 
-    def _print_diff(self, project_and_group: str, configuration):
+    def _print_diff(self, project_and_group: str, configuration, only_changed: bool = False):
         try:
             current_variables = self.gitlab.get_variables(project_and_group)
 

--- a/gitlabform/processors/single_entity_processor.py
+++ b/gitlabform/processors/single_entity_processor.py
@@ -50,11 +50,12 @@ class SingleEntityProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
             self.add_method(project_or_group, entity_config)
             debug(f"{self.configuration_name} AFTER: ^^^")
 
-    def _print_diff(self, project_or_project_and_group: str, entity_config):
+    def _print_diff(self, project_or_project_and_group: str, entity_config, diff_only_changed: bool):
         entity_in_gitlab = self.get_method(project_or_project_and_group)
 
         DifferenceLogger.log_diff(
             f"{self.configuration_name} changes",
             entity_in_gitlab,
             entity_config,
+            only_changed=diff_only_changed,
         )

--- a/gitlabform/processors/single_entity_processor.py
+++ b/gitlabform/processors/single_entity_processor.py
@@ -50,7 +50,9 @@ class SingleEntityProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
             self.add_method(project_or_group, entity_config)
             debug(f"{self.configuration_name} AFTER: ^^^")
 
-    def _print_diff(self, project_or_project_and_group: str, entity_config, diff_only_changed: bool):
+    def _print_diff(
+        self, project_or_project_and_group: str, entity_config, diff_only_changed: bool
+    ):
         entity_in_gitlab = self.get_method(project_or_project_and_group)
 
         DifferenceLogger.log_diff(

--- a/gitlabform/processors/util/difference_logger.py
+++ b/gitlabform/processors/util/difference_logger.py
@@ -3,7 +3,6 @@ import json
 from itertools import starmap
 
 from cli_ui import debug as verbose
-from cli_ui import info
 
 
 # Simple function to create strings for values which should be hidden
@@ -68,12 +67,6 @@ class DifferenceLogger:
         text = "{subject}:\n{diff}".format(
             subject=subject, diff="\n".join(starmap(pattern.format, changes))
         )
-
-        # Setting this for now, but open to change this
-        # This avoids users having to set --verbose to see
-        # the settings that are being changed.
-        if only_changed:
-            info(text)
 
         if test:
             return text

--- a/gitlabform/processors/util/difference_logger.py
+++ b/gitlabform/processors/util/difference_logger.py
@@ -3,6 +3,7 @@ import json
 from itertools import starmap
 
 from cli_ui import debug as verbose
+from cli_ui import info
 
 
 # Simple function to create strings for values which should be hidden
@@ -27,7 +28,7 @@ class DifferenceLogger:
                 k,
                 json.dumps(
                     current_config.get(k, "???")
-                    if type(current_config) == dict
+                    if isinstance(current_config, dict)
                     else "???"
                 ),
                 json.dumps(v),
@@ -37,7 +38,10 @@ class DifferenceLogger:
 
         # Remove unchanged if needed
         if only_changed:
-            changes = filter(lambda i: i[1] != i[2], changes)
+            # due to `filter` returning an iterator, we have to wrap it
+            # in `list()` to get the values and assign back to `changes`,
+            # otherwise `changes` is not what we expect it to be later :)
+            changes = list(filter(lambda i: i[1] != i[2], changes))
 
         # Hide secrets
         if hide_entries:
@@ -64,6 +68,13 @@ class DifferenceLogger:
         text = "{subject}:\n{diff}".format(
             subject=subject, diff="\n".join(starmap(pattern.format, changes))
         )
+
+        # Setting this for now, but open to change this
+        # This avoids users having to set --verbose to see
+        # the settings that are being changed.
+        if only_changed:
+            info(text)
+
         if test:
             return text
         else:

--- a/tests/unit/processors/test_difference_logger.py
+++ b/tests/unit/processors/test_difference_logger.py
@@ -42,3 +42,24 @@ def test_none_current():
     """
     ).strip()
     assert result == expected
+
+def test_diff_from_current():
+    current_config = {
+        "foo": 456,
+        "bar": "whatever",
+    }
+    config_to_apply = {
+        "foo": 123,
+        "bar": "whatever",
+    }
+    result = DifferenceLogger.log_diff(
+        "test", current_config, config_to_apply, True, None, True
+    )
+    # the whitespace after "123" below is required!
+    expected = textwrap.dedent(
+        """
+        test:
+        foo: 456 => 123       
+    """
+    ).strip()
+    assert result == expected

--- a/tests/unit/processors/test_difference_logger.py
+++ b/tests/unit/processors/test_difference_logger.py
@@ -43,6 +43,7 @@ def test_none_current():
     ).strip()
     assert result == expected
 
+
 def test_diff_from_current():
     current_config = {
         "foo": 456,


### PR DESCRIPTION
Partially solves #290

Just looking to clear up the output a bit, especially when working with larger numbers of projects. In my case, we can often be working with 10s or hundreds of projects at a time. Limiting the output to just what is changing (more similar to Terraform's `plan` output) helps keep things easier to read :)

Both `--verbose` and `--diff-only-changed` must be set to have the desired output.

I'd personally hope that we could work towards a way to see this kind of output without having to set `--verbose`, but I'll circle back on that later :smile: 

Config I used to generate my output:

```yaml
config_version: 3

projects_and_groups:
  fancy-group-isa/*:
    project_settings:
      default_branch: main
      visibility: public
```

Command I ran:

```shell
gitlabform -n -v --diff-only-changed -c config-develop.yml ALL
```

Output I received:

```
🏗 GitLabForm version: 3.14.1 = the latest stable 😊
Reading config from file: config-develop.yml
Connected to GitLab version: 17.3.1-ee (df01858216e)
Connected as: root, admin: yes
Running in dry-run mode...
>>> Getting ALL groups and projects that I have permission to modify...
:: # of groups to process: 0
:: (# of omitted groups - empty effective config: 1)
groups: []
omitted groups - empty effective config: ['fancy-group-isa']
:: # of projects to process: 1
projects: ['fancy-group-isa/my-awesome-project']
* (1/1) Processing project: fancy-group-isa/my-awesome-project
Skipping section 'project' - not in config.
Processing section 'project_settings' in dry-run mode.
project_settings changes:
visibility: "private" => "public"
Skipping section 'project_push_rules' - not in config.
Skipping section 'labels' - not in config.
Skipping section 'job_token_scope' - not in config.
Skipping section 'deploy_keys' - not in config.
Skipping section 'variables' - not in config.
Skipping section 'branches' - not in config.
Skipping section 'tags' - not in config.
Skipping section 'integrations' - not in config.
Skipping section 'files' - not in config.
Skipping section 'hooks' - not in config.
Skipping section 'members' - not in config.
Skipping section 'schedules' - not in config.
Skipping section 'badges' - not in config.
Skipping section 'resource_groups' - not in config.
Skipping section 'protected_environments' - not in config.
Skipping section 'merge_requests_approvals' - not in config.
Skipping section 'merge_requests_approval_rules' - not in config.
:: # of groups processed successfully: 0
:: # of projects processed successfully: 1
:: All requested groups/projects processed successfully! ✨

```

