### PR TITLE
fix: saml group link idempotent update

### DIFF
--- a/gitlabform/processors/group/group_saml_links_processor.py
+++ b/gitlabform/processors/group/group_saml_links_processor.py
@@ -28,8 +28,9 @@ class GroupSAMLLinksProcessor(AbstractProcessor):
         if enforce_links:
             configured_links.pop("enforce")
 
-        for link_name, link_configuration in configured_links.items():
-            if link_name not in existing_link_names:
+        for _, link_configuration in configured_links.items():
+            saml_group_name = link_configuration.get("saml_group_name")
+            if saml_group_name not in existing_link_names:
                 group.saml_group_links.create(link_configuration)
                 group.save()
 
@@ -48,7 +49,7 @@ class GroupSAMLLinksProcessor(AbstractProcessor):
     ) -> None:
         """Delete any SAML links that are not in the configuration."""
         known_names = [
-            common_name["name"]
+            common_name["saml_group_name"]
             for common_name in configured.values()
             if common_name != "enforce"
         ]
@@ -56,4 +57,4 @@ class GroupSAMLLinksProcessor(AbstractProcessor):
         for link in existing:
             if link.name not in known_names:
                 debug(f"Deleting extra SAML link: {link.name}")
-                group.saml_group_links.delete(link.id)
+                group.saml_group_links.delete(link.name)

--- a/tests/acceptance/premium/test_group_settings.py
+++ b/tests/acceptance/premium/test_group_settings.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests.acceptance import run_gitlabform
+from gitlabform.gitlab import AccessLevel
 
 pytestmark = pytest.mark.requires_license
 
@@ -35,3 +36,43 @@ class TestGroupSettings:
         run_gitlabform(add_group_saml_settings, group)
         refreshed_group = gl.groups.get(group.id)
         assert len(refreshed_group.saml_group_links.list()) == 1
+
+    def test__enforce_saml_links_premium(self, gl, group_for_function):
+
+        assert (
+            len(group_for_function.saml_group_links.list()) == 0
+        ), "saml_group_links is not empty"
+
+        add_group_saml_settings = f"""
+          projects_and_groups:
+            {group_for_function.full_path}/*:              
+              saml_group_links: 
+                devops_are_maintainers:                                 
+                  saml_group_name: devops_maintainer
+                  access_level: maintainer
+                developers_are_developers:
+                  saml_group_name: developers
+                  access_level: developer
+                analysts_are_reporters:
+                  saml_group_name: analysts_reporter
+                  access_level: reporter
+          """
+        run_gitlabform(add_group_saml_settings, group_for_function)
+        refreshed_group = gl.groups.get(group_for_function.id)
+        assert len(refreshed_group.saml_group_links.list()) == 3
+
+        add_group_saml_settings_enforce = f"""
+          projects_and_groups:
+            {group_for_function.full_path}/*:              
+              saml_group_links: 
+                analysts_are_reporters:
+                  saml_group_name: analysts_reporter
+                  access_level: reporter
+                enforce: true
+          """
+        run_gitlabform(add_group_saml_settings_enforce, group_for_function)
+        refreshed_group = gl.groups.get(group_for_function.id)
+        saml_group_links = refreshed_group.saml_group_links.list()
+        assert len(saml_group_links) == 1
+        assert saml_group_links[0].name == "analysts_reporter"
+        assert saml_group_links[0].access_level == AccessLevel.get_value("reporter")


### PR DESCRIPTION
fixes #823 
Not using correct saml group link from the config to check existing links and it ends up treating them all as new. 

Also fixed link enforce with the correct group name. 