### PR TITLE
run gitlabform for a single group and all its subgroups

### DIFF
--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -55,6 +55,7 @@ class GitLabForm:
         config_string=None,
         noop=False,
         output_file=None,
+        recurse_subgroups=True,
     ):
         if target and config_string:
             # this mode is basically only for testing
@@ -74,6 +75,7 @@ class GitLabForm:
             self.just_show_version = False
             self.terminate_after_error = True
             self.only_sections = "all"
+            self.recurse_subgroups = recurse_subgroups
 
             self._configure_output(tests=True)
         else:
@@ -95,6 +97,7 @@ class GitLabForm:
                 self.just_show_version,
                 self.terminate_after_error,
                 self.only_sections,
+                self.recurse_subgroups,
             ) = self._parse_args()
 
             self._configure_output()
@@ -123,11 +126,13 @@ class GitLabForm:
         self.groups_provider = GroupsProvider(
             self.gitlab,
             self.configuration,
+            self.recurse_subgroups,
         )
         self.projects_provider = ProjectsProvider(
             self.gitlab,
             self.configuration,
             self.include_archived_projects,
+            self.recurse_subgroups,
         )
 
         self.groups_and_projects_filters = GroupsAndProjectsFilters(
@@ -280,6 +285,14 @@ class GitLabForm:
             help="process only section with these names (comma-delimited)",
         )
 
+        parser.add_argument(
+            "-r",
+            "--recurse-subgroups",
+            dest="recurse_subsgroups",
+            action="store_true",
+            help="include all subgroups recursively. Always true for ALL, ALL_DEFINED",
+        )
+
         args = parser.parse_args()
 
         if args.only_sections != "all":
@@ -301,6 +314,7 @@ class GitLabForm:
             args.just_show_version,
             args.terminate_after_error,
             args.only_sections,
+            args.recurse_subsgroups,
         )
 
     def _configure_output(self, tests=False) -> None:

--- a/gitlabform/gitlab/groups.py
+++ b/gitlabform/gitlab/groups.py
@@ -33,6 +33,11 @@ class GitLabGroups(GitLabCore):
     def get_group(self, name):
         return self._make_requests_to_api("groups/%s", name)
 
+    def get_group_descendants(self, group_id_or_path):
+        return self._make_requests_to_api(
+            "groups/%s/descendant_groups", group_id_or_path
+        )
+
     def get_groups(self):
         """
         :return: sorted list of groups

--- a/gitlabform/lists/groups.py
+++ b/gitlabform/lists/groups.py
@@ -1,10 +1,7 @@
 from cli_ui import fatal
-
 from gitlabform.constants import EXIT_INVALID_INPUT
-from gitlabform.lists import OmissionReason, Groups
-
-
 from gitlabform.gitlab.core import NotFoundException
+from gitlabform.lists import OmissionReason, Groups
 
 
 class GroupsProvider:
@@ -14,9 +11,10 @@ class GroupsProvider:
     and the fact that the group and project names case are somewhat case-sensitive.
     """
 
-    def __init__(self, gitlab, configuration):
+    def __init__(self, gitlab, configuration, recurse_subgroups):
         self.gitlab = gitlab
         self.configuration = configuration
+        self.recurse_subgroups = recurse_subgroups
 
     def get_groups(self, target: str) -> Groups:
         """
@@ -25,19 +23,29 @@ class GroupsProvider:
         """
 
         if target not in ["ALL", "ALL_DEFINED"]:
-            groups = self._get_single_group(target)
+            groups = self._get_single_group(target, self.recurse_subgroups)
         else:
             groups = self._get_groups(target)
 
         return groups
 
-    def _get_single_group(self, target: str) -> Groups:
+    def _get_single_group(self, target: str, recurse_subgroups: bool) -> Groups:
         groups = Groups()
 
         # it may be a subgroup or a group...
         try:
             maybe_group = self.gitlab.get_group_case_insensitive(target)
-            groups.add_requested([maybe_group["full_path"]])
+            path = maybe_group["full_path"]
+            groups.add_requested([path])
+
+            if recurse_subgroups:
+                descendants = self.gitlab.get_group_descendants(path)
+                groups.add_requested([group["full_path"] for group in descendants])
+
+                groups.add_omitted(
+                    OmissionReason.SKIPPED,
+                    self._get_skipped_groups(groups.get_effective()),
+                )
 
         except NotFoundException:
             # ...or a single project, which we ignore here

--- a/gitlabform/lists/projects.py
+++ b/gitlabform/lists/projects.py
@@ -18,8 +18,10 @@ class ProjectsProvider(GroupsProvider):
     Because the projects depend on groups requested, this class inherits GroupsProvider.
     """
 
-    def __init__(self, gitlab, configuration, include_archived_projects):
-        super().__init__(gitlab, configuration)
+    def __init__(
+        self, gitlab, configuration, include_archived_projects, recurse_subgroups
+    ):
+        super().__init__(gitlab, configuration, recurse_subgroups)
         self.include_archived_projects = include_archived_projects
 
     def get_projects(self, target: str) -> Projects:

--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -248,7 +248,12 @@ def randomize_case(input: str) -> str:
 
 
 def run_gitlabform(
-    config, target, include_archived_projects=True, noop=False, output_file=None
+    config,
+    target,
+    include_archived_projects=True,
+    noop=False,
+    output_file=None,
+    recurse_subgroups=True,
 ):
     # f-strings with """ used as configs have the disadvantage of having indentation in them - let's remove it here
     config = textwrap.dedent(config)
@@ -268,5 +273,6 @@ def run_gitlabform(
         target=target,
         noop=noop,
         output_file=output_file,
+        recurse_subgroups=recurse_subgroups,
     )
     gf.run()


### PR DESCRIPTION
solves https://github.com/gitlabform/gitlabform/issues/613

This feature is disabled by default and can be enabled with the cli flag `--recurse-subgroups` or `-r`.