### PR TITLE
dry-run mode - fix error on project variables with enforce option

### DIFF
--- a/gitlabform/processors/project/variables_processor.py
+++ b/gitlabform/processors/project/variables_processor.py
@@ -59,6 +59,13 @@ class VariablesProcessor(MultipleEntitiesProcessor):
         verbose(f"Variables in {project_and_group} in configuration:")
 
         configured_variables = copy.deepcopy(configuration)
+
+        enforce_variables = configured_variables.get("enforce", False)
+
+        # Remove 'enforce' key from the config so that it's not treated as a "variable"
+        if enforce_variables:
+            configured_variables.pop("enforce")
+
         for key in configured_variables.keys():
             configured_variables[key]["value"] = hide(
                 configured_variables[key]["value"]


### PR DESCRIPTION
This MR fix this error:

```
Config AFTER transformations:
%YAML 1.2
---
projects_and_groups:
   group/project:
      variables:
         enforce: true
         MY_VARIABLE:
            variable_type: env_var
            raw: true
            protected: false
            masked: false
            key: MY_VARIABLE
            value: '18'
Running in dry-run mode...

....

Variables in group/project in configuration:
Warning: Error occurred while processing project group/project, exception:
'bool' object is not subscriptable
Traceback (most recent call last):
  File "/home/webadm/.local/lib/python3.11/site-packages/gitlabform/__init__.py", line 482, in run
    self.project_processors.process_entity(
  File "/home/webadm/.local/lib/python3.11/site-packages/gitlabform/processors/__init__.py", line 31, in process_entity
    processor.process(
  File "/home/webadm/.local/lib/python3.11/site-packages/gitlabform/processors/util/decorators.py", line 42, in method_wrapper
    return method(self, project_and_group, SafeDict(configuration), *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dev/.local/lib/python3.11/site-packages/gitlabform/processors/abstract_processor.py", line 63, in process
    self._print_diff(
  File "/home/dev/.local/lib/python3.11/site-packages/gitlabform/processors/project/variables_processor.py", line 62, in _print_diff
    configured_variables[key]["value"]
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
TypeError: 'bool' object is not subscriptable
```