### PR TITLE
fix error when --diff-only-changed is set, but no changes are present

### DIFF
--- a/gitlabform/processors/util/difference_logger.py
+++ b/gitlabform/processors/util/difference_logger.py
@@ -53,6 +53,12 @@ class DifferenceLogger:
                 )
             )
 
+        # There is the potential that no changes need to be shown, which
+        # results in the calls to max() later on to fail. Instead, opting
+        # to return early with an emtpy string, since no changes were identified
+        if len(changes) == 0:
+            return ""
+
         # calculate field size for nice formatting
         max_key_len = str(max(map(lambda i: len(i[0]), changes)))
         max_val_1 = str(max(map(lambda i: len(i[1]), changes)))

--- a/tests/unit/processors/test_difference_logger.py
+++ b/tests/unit/processors/test_difference_logger.py
@@ -65,6 +65,7 @@ def test_diff_from_current():
     ).strip()
     assert result == expected
 
+
 def test_diff_output_no_changes():
     current_config = {
         "foo": 123,

--- a/tests/unit/processors/test_difference_logger.py
+++ b/tests/unit/processors/test_difference_logger.py
@@ -64,3 +64,23 @@ def test_diff_from_current():
     """
     ).strip()
     assert result == expected
+
+def test_diff_output_no_changes():
+    current_config = {
+        "foo": 123,
+        "bar": "whatever",
+    }
+    config_to_apply = {
+        "foo": 123,
+        "bar": "whatever",
+    }
+    result = DifferenceLogger.log_diff(
+        "test", current_config, config_to_apply, True, None, True
+    )
+
+    expected = textwrap.dedent(
+        """
+
+    """
+    ).strip()
+    assert result == expected


### PR DESCRIPTION
Found that if there were no changes to make and `--diff-only-changed` was set, that we'd run into the following error:

```
Warning: Error occurred while processing project <project name/path>, exception:
max() iterable argument is empty
```

This is due to the fact that with [here](https://github.com/gitlabform/gitlabform/blob/main/gitlabform/processors/util/difference_logger.py#L43) we set `changes` to a potential empty list. The empty list causes the call to `max()` [here](https://github.com/gitlabform/gitlabform/blob/main/gitlabform/processors/util/difference_logger.py#L57-L59) to error out.

Opting to simply return early with an empty string when changes is empty to avoid running into the error.