### PR TITLE
fix: iterates through project list to check and add members

### DIFF
--- a/gitlabform/processors/project/members_processor.py
+++ b/gitlabform/processors/project/members_processor.py
@@ -233,7 +233,7 @@ class MembersProcessor(AbstractProcessor):
     def _get_members_from_project(project):
         # Only get direct members from Python Gitlab (matches previous implementation)
         # https://python-gitlab.readthedocs.io/en/stable/gl_objects/projects.html#id14
-        project_members = project.members.list()
+        project_members = project.members.list(iterator=True)
         existing_user_names_lower = dict()
 
         for member in project_members:

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -321,6 +321,21 @@ def make_project_member_developer_random_case(gl, project_for_function):
     gl.users.delete(user.id)
 
 
+@pytest.fixture(scope="function")
+def make_multiple_project_members_for_pagination(gl, project_for_function):
+    users = create_users(randomize_case(get_random_name("user")), 25)
+
+    for user in users:
+        project_for_function.members.create(
+            {"user_id": user.id, "access_level": AccessLevel.DEVELOPER.value}
+        )
+
+    yield users
+
+    for user in users:
+        user.delete()
+
+
 def _create_user_and_add_to_project(gl, project, username):
     user = gl.users.create(
         {


### PR DESCRIPTION
This fixes the issue #836 for the condition when member list is paginated.