### PR TITLE
fix: project settings failing to apply because membership config is not processed

### DIFF
--- a/gitlabform/processors/multiple_entities_processor.py
+++ b/gitlabform/processors/multiple_entities_processor.py
@@ -70,7 +70,7 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
         else:
             enforce = False
 
-        if "members" in configuration and "protected_environments" in configuration:
+        if "members" in configuration and ("protected_environments" or "merge_requests_approval_rules") in configuration:
             # When gitlabform needs to update project membership and also
             # configure environment protection, there seems to be a race condition
             # or delay in GitLab. Automated acceptance tests in gitlabform 
@@ -80,6 +80,7 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
             # the API does not include that user in protected environment config and
             # does not return any error either"
             time.sleep(2)
+
         # TODO: move/convert this to a configuration validation phase
         self._find_duplicates(project_or_group, entities_in_configuration)
 

--- a/gitlabform/processors/multiple_entities_processor.py
+++ b/gitlabform/processors/multiple_entities_processor.py
@@ -75,10 +75,10 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
             and ("protected_environments" or "merge_requests_approval_rules")
             in configuration
         ):
-            # When gitlabform needs to update project membership and also configure 
-            # settings that are dependent on the members (i.e. environment protection 
-            # or MR approval rule), there seems to be an issue in GitLab. Automated 
-            # acceptance tests in gitlabform creates new user and adds to the project 
+            # When gitlabform needs to update project membership and also configure
+            # settings that are dependent on the members (i.e. environment protection
+            # or MR approval rule), there seems to be an issue in GitLab. Automated
+            # acceptance tests in gitlabform creates new user and adds to the project
             # followed by configuring other setting. In that scenario need to wait a little
             # before calling GitLab's REST API for processing other settings. Otherwise
             # the users are not available to be configured in other settings and it

--- a/gitlabform/processors/multiple_entities_processor.py
+++ b/gitlabform/processors/multiple_entities_processor.py
@@ -70,14 +70,18 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
         else:
             enforce = False
 
-        if "members" in configuration and ("protected_environments" or "merge_requests_approval_rules") in configuration:
-            # When gitlabform needs to update project membership and also
-            # configure environment protection, there seems to be a race condition
-            # or delay in GitLab. Automated acceptance tests in gitlabform 
-            # creates new user and adds to the project followed by configuring 
-            # environment protection setting. In that scenario need to wait a little 
-            # before calling GitLab's REST API for environment protection. Otherwise 
-            # the API does not include that user in protected environment config and
+        if (
+            "members" in configuration
+            and ("protected_environments" or "merge_requests_approval_rules")
+            in configuration
+        ):
+            # When gitlabform needs to update project membership and also configure 
+            # settings that are dependent on the members (i.e. environment protection 
+            # or MR approval rule), there seems to be an issue in GitLab. Automated 
+            # acceptance tests in gitlabform creates new user and adds to the project 
+            # followed by configuring other setting. In that scenario need to wait a little
+            # before calling GitLab's REST API for processing other settings. Otherwise
+            # the users are not available to be configured in other settings and it
             # does not return any error either"
             time.sleep(2)
 

--- a/gitlabform/processors/multiple_entities_processor.py
+++ b/gitlabform/processors/multiple_entities_processor.py
@@ -4,7 +4,7 @@ from cli_ui import fatal
 
 import abc
 from typing import Callable, Union, Any
-
+import time
 from gitlabform.constants import EXIT_INVALID_INPUT
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -70,6 +70,16 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
         else:
             enforce = False
 
+        if "members" in configuration and "protected_environments" in configuration:
+            # When gitlabform needs to update project membership and also
+            # configure environment protection, there seems to be a race condition
+            # or delay in GitLab. Automated acceptance tests in gitlabform 
+            # creates new user and adds to the project followed by configuring 
+            # environment protection setting. In that scenario need to wait a little 
+            # before calling GitLab's REST API for environment protection. Otherwise 
+            # the API does not include that user in protected environment config and
+            # does not return any error either"
+            time.sleep(2)
         # TODO: move/convert this to a configuration validation phase
         self._find_duplicates(project_or_group, entities_in_configuration)
 

--- a/gitlabform/processors/project/__init__.py
+++ b/gitlabform/processors/project/__init__.py
@@ -57,6 +57,7 @@ class ProjectProcessors(AbstractProcessors):
         self.processors: List[AbstractProcessor] = [
             ProjectProcessor(gitlab),
             ProjectSettingsProcessor(gitlab),
+            MembersProcessor(gitlab),
             ProjectPushRulesProcessor(gitlab),
             ProjectLabelsProcessor(gitlab),
             JobTokenScopeProcessor(gitlab),
@@ -67,7 +68,6 @@ class ProjectProcessors(AbstractProcessors):
             IntegrationsProcessor(gitlab),
             FilesProcessor(gitlab, config, strict),
             HooksProcessor(gitlab),
-            MembersProcessor(gitlab),
             SchedulesProcessor(gitlab),
             BadgesProcessor(gitlab),
             ResourceGroupsProcessor(gitlab),

--- a/gitlabform/processors/project/__init__.py
+++ b/gitlabform/processors/project/__init__.py
@@ -59,7 +59,7 @@ class ProjectProcessors(AbstractProcessors):
             # in the order listed below. Settings that are related to each other,
             # should be ordered accordingly. For example, branch protection or MR
             # approvals can configure specific users, but the user must be a
-            # member of the project. So, project membership must be processed 
+            # member of the project. So, project membership must be processed
             # before those processors.
             ProjectProcessor(gitlab),
             ProjectSettingsProcessor(gitlab),

--- a/gitlabform/processors/project/__init__.py
+++ b/gitlabform/processors/project/__init__.py
@@ -55,6 +55,12 @@ class ProjectProcessors(AbstractProcessors):
     def __init__(self, gitlab: GitLab, config: Configuration, strict: bool):
         super().__init__(gitlab, config, strict)
         self.processors: List[AbstractProcessor] = [
+            # Order of processors matter. GitLabForm will process config sections
+            # in the order listed below. Settings that are related to each other,
+            # should be ordered accordingly. For example, branch protection or MR
+            # approvals can configure specific users, but the user must be a
+            # member of the project. So, project membership must be processed 
+            # before those processors.
             ProjectProcessor(gitlab),
             ProjectSettingsProcessor(gitlab),
             MembersProcessor(gitlab),

--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -1,7 +1,8 @@
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
 from gitlabform.processors.util.branch_protector import BranchProtector
-
+from cli_ui import debug as verbose, warning
+import time
 
 class BranchesProcessor(AbstractProcessor):
     def __init__(self, gitlab: GitLab, strict: bool):
@@ -10,6 +11,18 @@ class BranchesProcessor(AbstractProcessor):
 
     def _process_configuration(self, project_and_group: str, configuration: dict):
         for branch in sorted(configuration["branches"]):
+            if "members" in configuration:
+                # When gitlabform needs to update project membership and also
+                # configure branch protection, there seems to be a race condition
+                # or delay in GitLab. Automated acceptance tests in gitlabform 
+                # creates new user and adds to the project followed by configuring 
+                # branch protection setting. In that scenario need to wait a little 
+                # before calling GitLab's REST API for branch protection. Otherwise 
+                # the API returns error code 422 with an message like "Push access 
+                # levels user is not a member of the project"
+
+                time.sleep(2)
+
             self.__branch_protector.apply_branch_protection_configuration(
                 project_and_group, configuration, branch
             )

--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -4,6 +4,7 @@ from gitlabform.processors.util.branch_protector import BranchProtector
 from cli_ui import debug as verbose, warning
 import time
 
+
 class BranchesProcessor(AbstractProcessor):
     def __init__(self, gitlab: GitLab, strict: bool):
         super().__init__("branches", gitlab)
@@ -14,11 +15,11 @@ class BranchesProcessor(AbstractProcessor):
             if "members" in configuration:
                 # When gitlabform needs to update project membership and also
                 # configure branch protection, there seems to be a race condition
-                # or delay in GitLab. Automated acceptance tests in gitlabform 
-                # creates new user and adds to the project followed by configuring 
-                # branch protection setting. In that scenario need to wait a little 
-                # before calling GitLab's REST API for branch protection. Otherwise 
-                # the API returns error code 422 with an message like "Push access 
+                # or delay in GitLab. Automated acceptance tests in gitlabform
+                # creates new user and adds to the project followed by configuring
+                # branch protection setting. In that scenario need to wait a little
+                # before calling GitLab's REST API for branch protection. Otherwise
+                # the API returns error code 422 with an message like "Push access
                 # levels user is not a member of the project"
 
                 time.sleep(2)

--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -1,7 +1,6 @@
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
 from gitlabform.processors.util.branch_protector import BranchProtector
-from cli_ui import debug as verbose, warning
 import time
 
 

--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -251,6 +251,59 @@ def get_only_tag_access_levels(project: Project, tag):
     )
 
 
+def get_only_environment_access_levels(project: Project, environment):
+    """
+    Retrieve details of a given protected environments so that
+    tests can easily validate those accordingly.
+    TODO: Should also return details about `required_approvals`
+    and `group_inheritance_type` for each
+    access levels or approval rules.
+    """
+    protected_environment = None
+
+    with allowed_codes(404):
+        protected_environment = project.protected_environments.get(environment)
+
+    if not protected_environment:
+        return None, None, None, None, None, None, None
+
+    deploy_access_levels = set()
+    deploy_access_user_ids = set()
+    deploy_access_group_ids = set()
+    approval_rules_access_levels = set()
+    approval_rules_user_ids = set()
+    approval_rules_group_ids = set()
+    required_approval_count = 0
+
+    if "deploy_access_levels" in protected_environment.attributes:
+        for deploy_access in protected_environment.deploy_access_levels:
+            if not deploy_access["user_id"] and not deploy_access["group_id"]:
+                deploy_access_levels.add(deploy_access["access_level"])
+            elif deploy_access["user_id"]:
+                deploy_access_user_ids.add(deploy_access["user_id"])
+            elif deploy_access["group_id"]:
+                deploy_access_group_ids.add(deploy_access["group_id"])
+
+    if "approval_rules" in protected_environment.attributes:
+        for approval_rules in protected_environment.approval_rules:
+            if not approval_rules["user_id"] and not approval_rules["group_id"]:
+                approval_rules_access_levels.add(approval_rules["access_level"])
+            elif approval_rules["user_id"]:
+                approval_rules_user_ids.add(approval_rules["user_id"])
+            elif approval_rules["group_id"]:
+                approval_rules_group_ids.add(approval_rules["group_id"])
+
+    return (
+        sorted(deploy_access_levels),
+        sorted(deploy_access_user_ids),
+        sorted(deploy_access_group_ids),
+        sorted(approval_rules_access_levels),
+        sorted(approval_rules_user_ids),
+        sorted(approval_rules_group_ids),
+        required_approval_count,
+    )
+
+
 def randomize_case(input: str) -> str:
     return "".join(random.choice((str.upper, str.lower))(char) for char in input)
 

--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -171,27 +171,33 @@ def get_only_branch_access_levels(project: Project, branch):
         protected_branch = project.protectedbranches.get(branch)
 
     if not protected_branch:
-        return None, None, None, None, None
+        return None, None, None, None, None, None, None
 
     push_access_levels = set()
     merge_access_levels = set()
     push_access_user_ids = set()
     merge_access_user_ids = set()
+    push_access_group_ids = set()
+    merge_access_group_ids = set()
     unprotect_access_level = None
 
     if "push_access_levels" in protected_branch.attributes:
         for push_access in protected_branch.push_access_levels:
-            if not push_access["user_id"]:
+            if not push_access["user_id"] and not push_access["group_id"]:
                 push_access_levels.add(push_access["access_level"])
-            else:
+            elif push_access["user_id"]:
                 push_access_user_ids.add(push_access["user_id"])
+            elif push_access["group_id"]:
+                push_access_group_ids.add(push_access["group_id"])
 
     if "merge_access_levels" in protected_branch.attributes:
         for merge_access in protected_branch.merge_access_levels:
-            if not merge_access["user_id"]:
+            if not merge_access["user_id"] and not merge_access["group_id"]:
                 merge_access_levels.add(merge_access["access_level"])
-            else:
+            elif merge_access["user_id"]:
                 merge_access_user_ids.add(merge_access["user_id"])
+            elif merge_access["group_id"]:
+                merge_access_group_ids.add(merge_access["group_id"])
 
     if (
         "unprotect_access_levels" in protected_branch.attributes
@@ -206,6 +212,8 @@ def get_only_branch_access_levels(project: Project, branch):
         sorted(merge_access_levels),
         sorted(push_access_user_ids),
         sorted(merge_access_user_ids),
+        sorted(push_access_group_ids),
+        sorted(merge_access_group_ids),
         unprotect_access_level,
     )
 

--- a/tests/acceptance/premium/test_branches.py
+++ b/tests/acceptance/premium/test_branches.py
@@ -57,31 +57,29 @@ class TestBranches:
         """
 
         run_gitlabform(config_with_user_ids, project)
-        assert True
-        # time.sleep(5)
 
-        # (
-        #     push_access_levels,
-        #     merge_access_levels,
-        #     push_access_user_ids,
-        #     merge_access_user_ids,
-        #     _,
-        # ) = get_only_branch_access_levels(project, branch)
+        (
+            push_access_levels,
+            merge_access_levels,
+            push_access_user_ids,
+            merge_access_user_ids,
+            _,
+        ) = get_only_branch_access_levels(project, branch)
 
-        # assert push_access_levels == [AccessLevel.NO_ACCESS.value]
-        # assert merge_access_levels == [AccessLevel.DEVELOPER.value]
-        # assert push_access_user_ids == sorted(
-        #     [
-        #         user_allowed_to_push.id,
-        #         user_allowed_to_push_and_merge.id,
-        #     ]
-        # )
-        # assert merge_access_user_ids == sorted(
-        #     [
-        #         user_allowed_to_merge.id,
-        #         user_allowed_to_push_and_merge.id,
-        #     ]
-        # )
+        assert push_access_levels == [AccessLevel.NO_ACCESS.value]
+        assert merge_access_levels == [AccessLevel.DEVELOPER.value]
+        assert push_access_user_ids == sorted(
+            [
+                user_allowed_to_push.id,
+                user_allowed_to_push_and_merge.id,
+            ]
+        )
+        assert merge_access_user_ids == sorted(
+            [
+                user_allowed_to_merge.id,
+                user_allowed_to_push_and_merge.id,
+            ]
+        )
 
     def test__allow_more_than_one_user_by_ids(self, project, branch, make_user):
         first_user = make_user(AccessLevel.DEVELOPER)

--- a/tests/acceptance/premium/test_branches.py
+++ b/tests/acceptance/premium/test_branches.py
@@ -124,16 +124,24 @@ class TestBranches:
         )
         assert merge_access_user_ids == []
 
-    def test__branch_protection_dependent_on_members(self, project_for_function, group_for_function, branch_for_function, make_user):
+    def test__branch_protection_dependent_on_members(
+        self, project_for_function, group_for_function, branch_for_function, make_user
+    ):
         """
         Configure a branch protection setting that depends on users or groups (i.e. allowed_to_merge)
         Make sure the setting is applied successfully because users must be members
         before they can be configured in branch protection setting.
         """
 
-        user_for_group_to_share_project_with = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
-        project_user_allowed_to_push = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
-        project_user_allowed_to_merge = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
+        user_for_group_to_share_project_with = make_user(
+            level=AccessLevel.DEVELOPER, add_to_project=False
+        )
+        project_user_allowed_to_push = make_user(
+            level=AccessLevel.DEVELOPER, add_to_project=False
+        )
+        project_user_allowed_to_merge = make_user(
+            level=AccessLevel.DEVELOPER, add_to_project=False
+        )
 
         config_branch_protection = f"""
         projects_and_groups:
@@ -194,8 +202,4 @@ class TestBranches:
                 project_user_allowed_to_merge.id,
             ]
         )
-        assert merge_access_group_ids == sorted(
-            [
-                group_for_function.id
-            ]
-        )
+        assert merge_access_group_ids == sorted([group_for_function.id])

--- a/tests/acceptance/premium/test_branches.py
+++ b/tests/acceptance/premium/test_branches.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 
 import gitlab
 
@@ -56,29 +57,31 @@ class TestBranches:
         """
 
         run_gitlabform(config_with_user_ids, project)
+        assert True
+        # time.sleep(5)
 
-        (
-            push_access_levels,
-            merge_access_levels,
-            push_access_user_ids,
-            merge_access_user_ids,
-            _,
-        ) = get_only_branch_access_levels(project, branch)
+        # (
+        #     push_access_levels,
+        #     merge_access_levels,
+        #     push_access_user_ids,
+        #     merge_access_user_ids,
+        #     _,
+        # ) = get_only_branch_access_levels(project, branch)
 
-        assert push_access_levels == [AccessLevel.NO_ACCESS.value]
-        assert merge_access_levels == [AccessLevel.DEVELOPER.value]
-        assert push_access_user_ids == sorted(
-            [
-                user_allowed_to_push.id,
-                user_allowed_to_push_and_merge.id,
-            ]
-        )
-        assert merge_access_user_ids == sorted(
-            [
-                user_allowed_to_merge.id,
-                user_allowed_to_push_and_merge.id,
-            ]
-        )
+        # assert push_access_levels == [AccessLevel.NO_ACCESS.value]
+        # assert merge_access_levels == [AccessLevel.DEVELOPER.value]
+        # assert push_access_user_ids == sorted(
+        #     [
+        #         user_allowed_to_push.id,
+        #         user_allowed_to_push_and_merge.id,
+        #     ]
+        # )
+        # assert merge_access_user_ids == sorted(
+        #     [
+        #         user_allowed_to_merge.id,
+        #         user_allowed_to_push_and_merge.id,
+        #     ]
+        # )
 
     def test__allow_more_than_one_user_by_ids(self, project, branch, make_user):
         first_user = make_user(AccessLevel.DEVELOPER)
@@ -122,8 +125,12 @@ class TestBranches:
         assert merge_access_user_ids == []
 
     def test__branch_protection_dependent_on_members(self, project_for_function, branch_for_function, make_user):
-        # Configure a branch protection setting that depends on users or groups (i.e. allowed_to_merge)
-        # Make sure the setting is applied successfully
+        """
+        Configure a branch protection setting that depends on users or groups (i.e. allowed_to_merge)
+        Make sure the setting is applied successfully because users must be members
+        before they can be configured in branch protection setting.
+        """
+
         user1 = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
         user2 = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
 
@@ -163,7 +170,7 @@ class TestBranches:
                 user1.id,
             ]
         )
-        assert merge_access_levels == [AccessLevel.DEVELOPER.value]
+        assert merge_access_levels == [AccessLevel.MAINTAINER.value]
         assert merge_access_user_ids == sorted(
             [
                 user2.id,

--- a/tests/acceptance/premium/test_branches.py
+++ b/tests/acceptance/premium/test_branches.py
@@ -124,34 +124,45 @@ class TestBranches:
         )
         assert merge_access_user_ids == []
 
-    def test__branch_protection_dependent_on_members(self, project_for_function, branch_for_function, make_user):
+    def test__branch_protection_dependent_on_members(self, project_for_function, group_for_function, branch_for_function, make_user):
         """
         Configure a branch protection setting that depends on users or groups (i.e. allowed_to_merge)
         Make sure the setting is applied successfully because users must be members
         before they can be configured in branch protection setting.
         """
 
-        user1 = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
-        user2 = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
+        user_for_group_to_share_project_with = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
+        project_user_allowed_to_push = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
+        project_user_allowed_to_merge = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
 
         config_branch_protection = f"""
         projects_and_groups:
+          {group_for_function.full_path}/*:
+            group_members:
+              users:
+                {user_for_group_to_share_project_with.username}:
+                  access_level: {AccessLevel.DEVELOPER.value}
           {project_for_function.path_with_namespace}:
             members:
               users:
-                {user1.username}:
+                {project_user_allowed_to_push.username}:
                   access_level: developer
-                {user2.username}:
+                {project_user_allowed_to_merge.username}:
                   access_level: developer
+              groups:
+                {group_for_function.full_path}:
+                  group_access: {AccessLevel.DEVELOPER.value}
             branches:
               {branch_for_function}:
                 protected: true
                 allowed_to_push:
                   - access_level: {AccessLevel.NO_ACCESS.value}
-                  - user_id: {user1.id}
+                  - user_id: {project_user_allowed_to_push.id}
+                  - group_id: {group_for_function.id}
                 allowed_to_merge:
                   - access_level: {AccessLevel.MAINTAINER.value}
-                  - user: {user2.username}
+                  - user: {project_user_allowed_to_merge.username}
+                  - group_id: {group_for_function.id}
         """
 
         run_gitlabform(config_branch_protection, project_for_function)
@@ -161,18 +172,30 @@ class TestBranches:
             merge_access_levels,
             push_access_user_ids,
             merge_access_user_ids,
+            push_access_group_ids,
+            merge_access_group_ids,
             _,
         ) = get_only_branch_access_levels(project_for_function, branch_for_function)
 
         assert push_access_levels == [AccessLevel.NO_ACCESS.value]
         assert push_access_user_ids == sorted(
             [
-                user1.id,
+                project_user_allowed_to_push.id,
+            ]
+        )
+        assert push_access_group_ids == sorted(
+            [
+                group_for_function.id,
             ]
         )
         assert merge_access_levels == [AccessLevel.MAINTAINER.value]
         assert merge_access_user_ids == sorted(
             [
-                user2.id,
+                project_user_allowed_to_merge.id,
+            ]
+        )
+        assert merge_access_group_ids == sorted(
+            [
+                group_for_function.id
             ]
         )

--- a/tests/acceptance/premium/test_branches.py
+++ b/tests/acceptance/premium/test_branches.py
@@ -64,6 +64,8 @@ class TestBranches:
             push_access_user_ids,
             merge_access_user_ids,
             _,
+            _,
+            _,
         ) = get_only_branch_access_levels(project, branch)
 
         assert push_access_levels == [AccessLevel.NO_ACCESS.value]
@@ -108,6 +110,8 @@ class TestBranches:
             merge_access_levels,
             push_access_user_ids,
             merge_access_user_ids,
+            _,
+            _,
             _,
         ) = get_only_branch_access_levels(project, branch)
 

--- a/tests/acceptance/premium/test_branches_users_case_insensitive.py
+++ b/tests/acceptance/premium/test_branches_users_case_insensitive.py
@@ -44,6 +44,8 @@ class TestBranchesUsersCaseInsensitive:
             push_access_user_ids,
             merge_access_user_ids,
             _,
+            _,
+            _,
         ) = get_only_branch_access_levels(project, branch)
 
         assert push_access_levels == [AccessLevel.MAINTAINER.value]

--- a/tests/acceptance/premium/test_merge_request_approval_rules.py
+++ b/tests/acceptance/premium/test_merge_request_approval_rules.py
@@ -467,15 +467,21 @@ class TestMergeRequestApprovers:
 
         assert first_found and second_found
 
-    def test__merge_request_approval_rule_dependent_on_members(self, project_for_function, group_for_function, make_user):
+    def test__merge_request_approval_rule_dependent_on_members(
+        self, project_for_function, group_for_function, make_user
+    ):
         """
         Configure merge request approval rule setting that depends on users or groups,
         Make sure the setting is applied successfully because users must be members
         before they can be configured in approval rule setting.
         """
 
-        user_for_group_to_share_project_with = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
-        project_user_for_approval_rule = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
+        user_for_group_to_share_project_with = make_user(
+            level=AccessLevel.DEVELOPER, add_to_project=False
+        )
+        project_user_for_approval_rule = make_user(
+            level=AccessLevel.DEVELOPER, add_to_project=False
+        )
         # project_user_allowed_to_approve = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
 
         config_branch_protection = f"""
@@ -504,7 +510,7 @@ class TestMergeRequestApprovers:
         """
 
         run_gitlabform(config_branch_protection, project_for_function)
-        
+
         mr_approval_rules_under_this_project = project_for_function.approvalrules.list()
         assert len(mr_approval_rules_under_this_project) == 1
         default_mr_approval_rule_details = mr_approval_rules_under_this_project[0]
@@ -513,6 +519,12 @@ class TestMergeRequestApprovers:
 
         assert default_mr_approval_rule_details.approvals_required == 2
         assert len(default_mr_approval_rule_details.users) == 1
-        assert default_mr_approval_rule_details.users[0]["username"] == project_user_for_approval_rule.username
+        assert (
+            default_mr_approval_rule_details.users[0]["username"]
+            == project_user_for_approval_rule.username
+        )
         assert len(default_mr_approval_rule_details.groups) == 1
-        assert default_mr_approval_rule_details.groups[0]["path"] == group_for_function.full_path
+        assert (
+            default_mr_approval_rule_details.groups[0]["path"]
+            == group_for_function.full_path
+        )

--- a/tests/acceptance/premium/test_merge_request_approval_rules.py
+++ b/tests/acceptance/premium/test_merge_request_approval_rules.py
@@ -466,3 +466,53 @@ class TestMergeRequestApprovers:
                 second_found = True
 
         assert first_found and second_found
+
+    def test__merge_request_approval_rule_dependent_on_members(self, project_for_function, group_for_function, make_user):
+        """
+        Configure merge request approval rule setting that depends on users or groups,
+        Make sure the setting is applied successfully because users must be members
+        before they can be configured in approval rule setting.
+        """
+
+        user_for_group_to_share_project_with = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
+        project_user_for_approval_rule = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
+        # project_user_allowed_to_approve = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
+
+        config_branch_protection = f"""
+        projects_and_groups:
+          {group_for_function.full_path}/*:
+            group_members:
+              users:
+                {user_for_group_to_share_project_with.username}:
+                  access_level: {AccessLevel.DEVELOPER.value}
+          {project_for_function.path_with_namespace}:
+            members:
+              users:
+                {project_user_for_approval_rule.username}:
+                  access_level: {AccessLevel.DEVELOPER.value}
+              groups:
+                {group_for_function.full_path}:
+                  group_access: {AccessLevel.DEVELOPER.value}
+            merge_requests_approval_rules:
+              default:
+                name: "Special approvers"
+                approvals_required: 2
+                users:
+                  - {project_user_for_approval_rule.username}
+                groups:
+                  - {group_for_function.full_path}
+        """
+
+        run_gitlabform(config_branch_protection, project_for_function)
+        
+        mr_approval_rules_under_this_project = project_for_function.approvalrules.list()
+        assert len(mr_approval_rules_under_this_project) == 1
+        default_mr_approval_rule_details = mr_approval_rules_under_this_project[0]
+        assert default_mr_approval_rule_details.name == "Special approvers"
+        print("approval rule details:", default_mr_approval_rule_details)
+
+        assert default_mr_approval_rule_details.approvals_required == 2
+        assert len(default_mr_approval_rule_details.users) == 1
+        assert default_mr_approval_rule_details.users[0]["username"] == project_user_for_approval_rule.username
+        assert len(default_mr_approval_rule_details.groups) == 1
+        assert default_mr_approval_rule_details.groups[0]["path"] == group_for_function.full_path

--- a/tests/acceptance/premium/test_protected_environments.py
+++ b/tests/acceptance/premium/test_protected_environments.py
@@ -160,16 +160,24 @@ class TestProtectedEnvironments:
             == other_group.id
         )
 
-    def test__environment_protection_dependent_on_members(self, project_for_function, group_for_function, make_user):
+    def test__environment_protection_dependent_on_members(
+        self, project_for_function, group_for_function, make_user
+    ):
         """
         Configure an environment protection setting that depends on users or groups (i.e. allowed_to_deploy)
         Make sure the setting is applied successfully because users must be members
         before they can be configured in environment protection setting.
         """
 
-        user_for_group_to_share_project_with = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
-        project_user_allowed_to_deploy = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
-        project_user_allowed_to_approve = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
+        user_for_group_to_share_project_with = make_user(
+            level=AccessLevel.DEVELOPER, add_to_project=False
+        )
+        project_user_allowed_to_deploy = make_user(
+            level=AccessLevel.DEVELOPER, add_to_project=False
+        )
+        project_user_allowed_to_approve = make_user(
+            level=AccessLevel.DEVELOPER, add_to_project=False
+        )
 
         config_branch_protection = f"""
         projects_and_groups:
@@ -202,8 +210,10 @@ class TestProtectedEnvironments:
         """
 
         run_gitlabform(config_branch_protection, project_for_function)
-        
-        protected_envs_under_this_project = project_for_function.protected_environments.list()
+
+        protected_envs_under_this_project = (
+            project_for_function.protected_environments.list()
+        )
         assert len(protected_envs_under_this_project) == 1
         production_env_protection_details = protected_envs_under_this_project[0]
         assert production_env_protection_details.name == "production"
@@ -236,8 +246,4 @@ class TestProtectedEnvironments:
                 project_user_allowed_to_approve.id,
             ]
         )
-        assert approval_rules_group_ids == sorted(
-            [
-                group_for_function.id
-            ]
-        )
+        assert approval_rules_group_ids == sorted([group_for_function.id])

--- a/tests/acceptance/standard/test_branches.py
+++ b/tests/acceptance/standard/test_branches.py
@@ -22,6 +22,8 @@ class TestBranches:
             merge_access_levels,
             push_access_user_ids,
             merge_access_user_ids,
+            _,
+            _,
             unprotect_access_level,
         ) = get_only_branch_access_levels(project, branch)
         assert push_access_levels == [AccessLevel.NO_ACCESS.value]
@@ -48,6 +50,8 @@ class TestBranches:
             merge_access_levels,
             push_access_user_ids,
             merge_access_user_ids,
+            _,
+            _,
             unprotect_access_level,
         ) = get_only_branch_access_levels(project, branch)
         assert push_access_levels is None
@@ -75,6 +79,8 @@ class TestBranches:
             merge_access_level,
             push_access_user_ids,
             merge_access_user_ids,
+            _,
+            _,
             unprotect_access_level,
         ) = get_only_branch_access_levels(project, branch)
         assert push_access_level == [AccessLevel.NO_ACCESS.value]
@@ -117,6 +123,8 @@ class TestBranches:
         (
             push_access_level,
             merge_access_level,
+            _,
+            _,
             _,
             _,
             unprotect_access_level,

--- a/tests/acceptance/standard/test_branches.py
+++ b/tests/acceptance/standard/test_branches.py
@@ -138,6 +138,8 @@ class TestBranches:
             other_branch_merge_access_level,
             _,
             _,
+            _,
+            _,
             other_branch_unprotect_access_level,
         ) = get_only_branch_access_levels(
             project_for_function, other_branch_for_function

--- a/tests/acceptance/standard/test_files.py
+++ b/tests/acceptance/standard/test_files.py
@@ -205,6 +205,8 @@ class TestFiles:
             merge_access_levels,
             push_access_user_ids,
             merge_access_user_ids,
+            _,
+            _,
             unprotect_access_level,
         ) = get_only_branch_access_levels(project, branch)
         assert push_access_levels == [AccessLevel.MAINTAINER.value]
@@ -242,6 +244,8 @@ class TestFiles:
             merge_access_levels,
             push_access_user_ids,
             merge_access_user_ids,
+            _,
+            _,
             unprotect_access_level,
         ) = get_only_branch_access_levels(project, branch)
         assert push_access_levels == [AccessLevel.MAINTAINER.value]


### PR DESCRIPTION
There are certain features in GitLab that are related or dependent. For example:

- branch protection can be configured with granular option such as specific user or group is allowed to push or allowed merge.
- environment protection can be configured same way so that selected user or group is allowed to deploy.
- environment protection approval rules can also have similar setup as well
- merge request approval rules can be configured to select specific user or group

All of the above are dependent on membership of the project. The selected user must be a member with appropriate access or the project must be shared with the selected group.

Currently, GitLabForm's processing of various config happens in the order where membership config happens after processing branch protection setting and before processing other settings mentioned above. So, depending on the config used by the user, branch protection will fail because project's membership hasn't been processed yet and selected user/group is not a member of the project to be set in branch protection.

This MR fixes the above issue by moving the processing of project membership to happen earlier. It fixes the issue #765 

While the fix was very easy, the acceptance tests in gitlabform revealed a GitLab issue. When GitLabForm adds a user to a project and then configures other settings (i.e. branch protection, environment protection, merge request approvals), the same user cannot be configured immediately. For branch protection config, GitLab returns an error message about user not being a member of the project. This is same error mentioned in the issue #765. For other settings, there aren't any error but the settings do not configure the user as specified. This seems to match the bug reported in issue #644. @gdubicki had also encountered similar issue in the past in PR #521 (https://github.com/gitlabform/gitlabform/pull/521#discussion_r1155365504)

Because of above mentioned **GitLab issue**, I added a 2 second delay. This is a random number that allowed me to get the tests to pass on my local machine, although occasionally that wasn't enough. This is a performance hit to the users. I'm not sure if we should include this. In reality, this issue is likely going to happen rarely because the easy fix for users is to rerun gitlabform a 2nd time when the membership should already be set by GitLab and those settings will be configured successfully. But, without this I'm not sure how we can get our acceptance tests to pass and validate that gitlabform is working correctly.

resolves #764
related to #644 
