### PR TITLE
perf: reduce execution time due to project members config

### DIFF
--- a/gitlabform/processors/multiple_entities_processor.py
+++ b/gitlabform/processors/multiple_entities_processor.py
@@ -4,7 +4,6 @@ from cli_ui import fatal
 
 import abc
 from typing import Callable, Union, Any
-import time
 from gitlabform.constants import EXIT_INVALID_INPUT
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -69,21 +68,6 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
             del entities_in_configuration["enforce"]
         else:
             enforce = False
-
-        if (
-            "members" in configuration
-            and ("protected_environments" or "merge_requests_approval_rules")
-            in configuration
-        ):
-            # When gitlabform needs to update project membership and also configure
-            # settings that are dependent on the members (i.e. environment protection
-            # or MR approval rule), there seems to be an issue in GitLab. Automated
-            # acceptance tests in gitlabform creates new user and adds to the project
-            # followed by configuring other setting. In that scenario need to wait a little
-            # before calling GitLab's REST API for processing other settings. Otherwise
-            # the users are not available to be configured in other settings and it
-            # does not return any error either"
-            time.sleep(2)
 
         # TODO: move/convert this to a configuration validation phase
         self._find_duplicates(project_or_group, entities_in_configuration)

--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -10,7 +10,6 @@ from gitlab import (
 from gitlabform.constants import EXIT_INVALID_INPUT, EXIT_PROCESSING_ERROR
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
-import time
 
 
 class BranchesProcessor(AbstractProcessor):
@@ -19,18 +18,6 @@ class BranchesProcessor(AbstractProcessor):
         self.strict = strict
 
     def _process_configuration(self, project_and_group: str, configuration: dict):
-        if "members" in configuration:
-            # When gitlabform needs to update project membership and also
-            # configure branch protection, there seems to be a race condition
-            # or delay in GitLab. Automated acceptance tests in gitlabform
-            # creates new user and adds to the project followed by configuring
-            # branch protection setting. In that scenario need to wait a little
-            # before calling GitLab's REST API for branch protection. Otherwise
-            # the API returns error code 422 with an message like "Push access
-            # levels user is not a member of the project"
-
-            time.sleep(2)
-
         project: Project = self.gl.get_project_by_path_cached(project_and_group)
 
         for branch in sorted(configuration["branches"]):

--- a/tests/acceptance/premium/test_branches.py
+++ b/tests/acceptance/premium/test_branches.py
@@ -40,6 +40,9 @@ class TestBranches:
         user_allowed_to_merge = make_user(AccessLevel.DEVELOPER)
         user_allowed_to_push_and_merge = make_user(AccessLevel.DEVELOPER)
 
+        # Wait a little for newly created users to be available.
+        time.sleep(2)
+
         config_with_user_ids = f"""
         projects_and_groups:
           {project.path_with_namespace}:
@@ -144,6 +147,9 @@ class TestBranches:
         project_user_allowed_to_merge = make_user(
             level=AccessLevel.DEVELOPER, add_to_project=False
         )
+
+        # Wait a little for newly created users to be available.
+        time.sleep(2)
 
         config_branch_protection = f"""
         projects_and_groups:

--- a/tests/acceptance/premium/test_branches_users_case_insensitive.py
+++ b/tests/acceptance/premium/test_branches_users_case_insensitive.py
@@ -1,5 +1,5 @@
 import pytest
-
+import time
 from gitlabform.gitlab import AccessLevel
 from tests.acceptance import (
     run_gitlabform,
@@ -20,6 +20,9 @@ class TestBranchesUsersCaseInsensitive:
         first_user = make_user(AccessLevel.DEVELOPER)
         second_user = make_user(AccessLevel.DEVELOPER)
         third_user = make_user(AccessLevel.DEVELOPER)
+
+        # Wait a little for newly created users to be available.
+        time.sleep(2)
 
         config_with_more_user_ids = f"""
         projects_and_groups:

--- a/tests/acceptance/premium/test_merge_request_approval_rules.py
+++ b/tests/acceptance/premium/test_merge_request_approval_rules.py
@@ -481,7 +481,6 @@ class TestMergeRequestApprovers:
         project_user_for_approval_rule = make_user(
             level=AccessLevel.DEVELOPER, add_to_project=False
         )
-        # project_user_allowed_to_approve = make_user(level = AccessLevel.DEVELOPER, add_to_project = False)
 
         config_branch_protection = f"""
         projects_and_groups:


### PR DESCRIPTION
Previously a change was relased in v4.0.1 that fixed the ordering of config processor. One change included in it increased the overall execution time of gitlabform if the config contained members for a project. This was due to acceptance tests failing when those users were being referenced in other config sections. The change added delays causing the execution time increase.

After further investigation, it seems that delay is only needed in the acceptance tests because gitlabform does not actually create users. The tests setup creates new users and in that case a small delay is needed.

This change removes the unnecessary delay that was included in the runtime of gitlabform. The delay has been added to necessary tests setup.