### PR TITLE
fix: wildcard based branch protection config fails to apply

### DIFF
--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -73,9 +73,7 @@ class BranchesProcessor(AbstractProcessor):
         elif protected_branch and not branch_config.get("protected"):
             self.unprotect_branch(protected_branch)
 
-    def protect_branch(
-        self, project: Project, branch: str, branch_config: dict
-    ):
+    def protect_branch(self, project: Project, branch: str, branch_config: dict):
         """
         Protect a branch using given config.
         Raise exception if running in strict mode.
@@ -86,9 +84,7 @@ class BranchesProcessor(AbstractProcessor):
         try:
             project.protectedbranches.create({"name": branch, **branch_config})
         except GitlabCreateError as e:
-            message = (
-                f"Protecting branch '{branch}' failed! Error '{e.error_message}"
-            )
+            message = f"Protecting branch '{branch}' failed! Error '{e.error_message}"
 
             if self.strict:
                 fatal(

--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -1,4 +1,3 @@
-import re
 from typing import Optional
 from logging import debug, info
 from cli_ui import warning, fatal
@@ -138,4 +137,4 @@ class BranchesProcessor(AbstractProcessor):
 
     @staticmethod
     def is_branch_name_wildcard(branch):
-        return re.fullmatch(".*\\*.*", branch)
+        return "*" in branch

--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -73,18 +73,20 @@ class BranchesProcessor(AbstractProcessor):
         elif protected_branch and not branch_config.get("protected"):
             self.unprotect_branch(protected_branch)
 
-    def protect_branch(self, project: Project, branch: str, branch_config: dict):
+    def protect_branch(self, project: Project, branch_name: str, branch_config: dict):
         """
         Protect a branch using given config.
         Raise exception if running in strict mode.
         """
 
-        debug("Setting branch '%s' as protected", branch)
+        debug("Setting branch '%s' as protected", branch_name)
 
         try:
-            project.protectedbranches.create({"name": branch, **branch_config})
+            project.protectedbranches.create({"name": branch_name, **branch_config})
         except GitlabCreateError as e:
-            message = f"Protecting branch '{branch}' failed! Error '{e.error_message}"
+            message = (
+                f"Protecting branch '{branch_name}' failed! Error '{e.error_message}"
+            )
 
             if self.strict:
                 fatal(

--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -36,11 +36,11 @@ class BranchesProcessor(AbstractProcessor):
         """
         protected_branch: Optional[ProjectProtectedBranch] = None
 
-        if not self.check_for_wildcard(branch_name):
+        if not self.is_branch_name_wildcard(branch_name):
             try:
                 branch = project.branches.get(branch_name)
             except GitlabGetError:
-                message = f"Branch '{branch_name}' not found when trying to processing it to be protected/unprotected!"
+                message = f"Branch '{branch_name}' not found when processing it to be protected/unprotected!"
                 if self.strict:
                     fatal(
                         message,
@@ -135,5 +135,5 @@ class BranchesProcessor(AbstractProcessor):
         return branch_config
 
     @staticmethod
-    def check_for_wildcard(branch):
+    def is_branch_name_wildcard(branch):
         return re.fullmatch(".*\\*.*", branch)

--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -1,7 +1,8 @@
+import re
 from typing import Optional
 from logging import debug, info
 from cli_ui import warning, fatal
-from gitlab.v4.objects import Project, ProjectBranch, ProjectProtectedBranch
+from gitlab.v4.objects import Project, ProjectProtectedBranch
 from gitlab import (
     GitlabGetError,
     GitlabDeleteError,
@@ -33,20 +34,20 @@ class BranchesProcessor(AbstractProcessor):
         """
         Process branch protection according to gitlabform config.
         """
-        branch: Optional[ProjectBranch] = None
         protected_branch: Optional[ProjectProtectedBranch] = None
 
-        try:
-            branch = project.branches.get(branch_name)
-        except GitlabGetError:
-            message = f"Branch '{branch_name}' not found when trying to processing it to be protected/unprotected!"
-            if self.strict:
-                fatal(
-                    message,
-                    exit_code=EXIT_INVALID_INPUT,
-                )
-            else:
-                warning(message)
+        if not self.check_for_wildcard(branch_name):
+            try:
+                branch = project.branches.get(branch_name)
+            except GitlabGetError:
+                message = f"Branch '{branch_name}' not found when trying to processing it to be protected/unprotected!"
+                if self.strict:
+                    fatal(
+                        message,
+                        exit_code=EXIT_INVALID_INPUT,
+                    )
+                else:
+                    warning(message)
 
         try:
             protected_branch = project.protectedbranches.get(branch_name)
@@ -54,7 +55,7 @@ class BranchesProcessor(AbstractProcessor):
             message = f"The branch '{branch_name}' is not protected!"
             debug(message)
 
-        if branch and branch_config.get("protected"):
+        if branch_config.get("protected"):
             if protected_branch and self._needs_update(
                 protected_branch.attributes, branch_config
             ):
@@ -66,27 +67,27 @@ class BranchesProcessor(AbstractProcessor):
                 # protected branch is not the same. So, removing existing branch protection and
                 # reconfiguring branch protection seems simpler.
                 self.unprotect_branch(protected_branch)
-                self.protect_branch(project, branch, branch_config)
+                self.protect_branch(project, branch_name, branch_config)
             elif not protected_branch:
-                self.protect_branch(project, branch, branch_config)
+                self.protect_branch(project, branch_name, branch_config)
         elif protected_branch and not branch_config.get("protected"):
             self.unprotect_branch(protected_branch)
 
     def protect_branch(
-        self, project: Project, branch: ProjectBranch, branch_config: dict
+        self, project: Project, branch: str, branch_config: dict
     ):
         """
         Protect a branch using given config.
         Raise exception if running in strict mode.
         """
 
-        debug("Setting branch '%s' as protected", branch.name)
+        debug("Setting branch '%s' as protected", branch)
 
         try:
-            project.protectedbranches.create({"name": branch.name, **branch_config})
+            project.protectedbranches.create({"name": branch, **branch_config})
         except GitlabCreateError as e:
             message = (
-                f"Protecting branch '{branch.name}' failed! Error '{e.error_message}"
+                f"Protecting branch '{branch}' failed! Error '{e.error_message}"
             )
 
             if self.strict:
@@ -136,3 +137,7 @@ class BranchesProcessor(AbstractProcessor):
                             item["group_id"] = self.gl.get_group_id(item.pop("group"))
 
         return branch_config
+
+    @staticmethod
+    def check_for_wildcard(branch):
+        return re.fullmatch(".*\\*.*", branch)

--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -137,4 +137,4 @@ class BranchesProcessor(AbstractProcessor):
 
     @staticmethod
     def is_branch_name_wildcard(branch):
-        return "*" in branch
+        return "*" in branch or "?" in branch

--- a/gitlabform/processors/project/files_processor.py
+++ b/gitlabform/processors/project/files_processor.py
@@ -243,12 +243,9 @@ class FilesProcessor(AbstractProcessor):
                     # ...and protect the branch again after the operation
                     if configuration.get("branches|" + branch.name + "|protected"):
                         debug("> Protecting the branch again.")
-                        project_branch: ProjectBranch = project.branches.get(
-                            branch.name
-                        )
                         branch_config: dict = configuration["branches"][branch.name]
                         self.branch_processor.protect_branch(
-                            project, project_branch, branch_config
+                            project, branch.name, branch_config
                         )
 
             else:

--- a/tests/acceptance/standard/test_branches.py
+++ b/tests/acceptance/standard/test_branches.py
@@ -66,7 +66,7 @@ class TestBranches:
         projects_and_groups:
           {project.path_with_namespace}:
             branches:
-              {branch_wildcard}:
+              "{branch_wildcard}":
                 protected: true
                 push_access_level: {AccessLevel.NO_ACCESS.value}
                 merge_access_level: {AccessLevel.MAINTAINER.value}

--- a/tests/acceptance/standard/test_branches.py
+++ b/tests/acceptance/standard/test_branches.py
@@ -90,6 +90,11 @@ class TestBranches:
         assert merge_access_user_ids == []
         assert unprotect_access_level is AccessLevel.MAINTAINER.value
 
+        wildcard_matching_branch = project.branches.create(
+            {"branch": "r-1", "ref": "main"}
+        )
+        assert wildcard_matching_branch.protected is True
+
     def test__config_with_access_level_names(self, project, branch):
         config_with_access_levels_names = f"""
         projects_and_groups:

--- a/tests/acceptance/standard/test_branches.py
+++ b/tests/acceptance/standard/test_branches.py
@@ -60,6 +60,36 @@ class TestBranches:
         assert merge_access_user_ids is None
         assert unprotect_access_level is None
 
+    def test__protect_with_wildcard(self, project):
+        branch_wildcard = "r-*"
+        config_protect_branch = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            branches:
+              {branch_wildcard}:
+                protected: true
+                push_access_level: {AccessLevel.NO_ACCESS.value}
+                merge_access_level: {AccessLevel.MAINTAINER.value}
+                unprotect_access_level: {AccessLevel.MAINTAINER.value}
+        """
+
+        run_gitlabform(config_protect_branch, project.path_with_namespace)
+
+        (
+            push_access_levels,
+            merge_access_levels,
+            push_access_user_ids,
+            merge_access_user_ids,
+            _,
+            _,
+            unprotect_access_level,
+        ) = get_only_branch_access_levels(project, branch_wildcard)
+        assert push_access_levels == [AccessLevel.NO_ACCESS.value]
+        assert merge_access_levels == [AccessLevel.MAINTAINER.value]
+        assert push_access_user_ids == []
+        assert merge_access_user_ids == []
+        assert unprotect_access_level is AccessLevel.MAINTAINER.value
+
     def test__config_with_access_level_names(self, project, branch):
         config_with_access_levels_names = f"""
         projects_and_groups:


### PR DESCRIPTION
This pull request refactors some of the logic to do with protected branches to fix a bug introduced in `4.0.2` of gitlab form. This bug is specifically to do with trying to protect a branch in gitlab using a wildcard. 

It adds a new acceptance test case to cover the new code. 

Closes #886 