### PR TITLE
refactor: use graphql to get member_roles to reduce permission level required

### DIFF
--- a/gitlabform/gitlab/__init__.py
+++ b/gitlabform/gitlab/__init__.py
@@ -2,6 +2,8 @@ import enum
 
 from typing import List
 
+from gitlab import GraphQL
+
 from gitlabform.gitlab.commits import GitLabCommits
 from gitlabform.gitlab.group_badges import GitLabGroupBadges
 from gitlabform.gitlab.group_ldap_links import GitLabGroupLDAPLinks
@@ -71,14 +73,17 @@ class GitlabWrapper:
         timeout = gitlabform.timeout
         session = gitlabform.session
 
+        graphql = GraphQL(url=url, token=token)
+
         self._gitlab: PythonGitlab = PythonGitlab(
-            url,
-            token,
+            url=url,
+            private_token=token,
             ssl_verify=ssl_verify,
-            api_version="4",
-            session=session,
-            retry_transient_errors=True,
             timeout=timeout,
+            api_version="4",
+            retry_transient_errors=True,
+            graphql=graphql,
+            session=session,
         )
 
     def get_gitlab(self):

--- a/gitlabform/gitlab/python_gitlab.py
+++ b/gitlabform/gitlab/python_gitlab.py
@@ -1,16 +1,58 @@
 import functools
-from typing import Union
-
-from cli_ui import debug
+from typing import Union, Any, Optional, Dict, List
 
 import gitlab.const
-from gitlab import Gitlab, GitlabGetError
+from gitlab import Gitlab, GitlabGetError, GraphQL
 from gitlab.base import RESTObject
 from gitlab.v4.objects import Group, Project
+
+from cli_ui import debug as verbose
 
 
 # Extends the python-gitlab class to add convenience wrappers for common functionality used within gitlabform
 class PythonGitlab(Gitlab):
+    def __init__(
+        self,
+        graphql: GraphQL,
+        url: Optional[str] = None,
+        private_token: Optional[str] = None,
+        oauth_token: Optional[str] = None,
+        job_token: Optional[str] = None,
+        ssl_verify: Union[bool, str] = True,
+        http_username: Optional[str] = None,
+        http_password: Optional[str] = None,
+        timeout: Optional[float] = None,
+        api_version: str = "4",
+        per_page: Optional[int] = None,
+        pagination: Optional[str] = None,
+        order_by: Optional[str] = None,
+        user_agent: str = gitlab.const.USER_AGENT,
+        retry_transient_errors: bool = False,
+        keep_base_url: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            url,
+            private_token,
+            oauth_token,
+            job_token,
+            ssl_verify,
+            http_username,
+            http_password,
+            timeout,
+            api_version,
+            per_page,
+            pagination,
+            order_by,
+            user_agent,
+            retry_transient_errors,
+            keep_base_url,
+            **kwargs,
+        )
+        # Python Gitlab GraphQL interface
+        # https://python-gitlab.readthedocs.io/en/stable/api-usage-graphql.html
+        self.graphql = graphql
+
     @functools.lru_cache()
     def get_user_id_cached(self, username) -> int:
         user = self._get_user_by_username_cached(username)
@@ -56,39 +98,128 @@ class PythonGitlab(Gitlab):
         return users[0]
 
     @functools.lru_cache()
-    def get_member_roles_cached(self, group_id: Union[int, None]):
-        """Python-Gitlab does not natively support Member Roles yet
-        use https://python-gitlab.readthedocs.io/en/stable/api-levels.html#lower-level-api-http-methods
-        to directly invoke member_roles GET endpoint(s) in GitLab
-        https://docs.gitlab.com/ee/api/member_roles.html
-        """
-        if self.is_gitlab_saas():
-            if group_id is None:
-                raise GitlabGetError(
-                    "Group Id must be provided when getting member roles on GitLab SaaS",
-                    404,
-                )
-            # SAAS
-            path = f"/groups/{group_id}/member_roles"
-        else:
-            # Self-Managed & Dedicated
-            path = f"/member_roles"
+    def _get_member_roles_from_group_cached(
+        self, group_full_path: str
+    ) -> List[Dict[str, str]]:
+        """Query GraphQL using Python Gitlab
+        https://python-gitlab.readthedocs.io/en/stable/api-usage-graphql.html
 
-        debug(f"Retrieving member roles from: {path}")
-        return self.http_get(path)
+        GET Member_Role via REST Api needs "Owner" on Gitlab.com or "Admin" on Dedicated
+        List of custom roles can be retrieved via GraphQL endpoint with "Guest+"
+        https://gitlab.com/gitlab-org/gitlab/-/issues/511919#note_2287581884
+
+        https://docs.gitlab.com/ee/api/graphql/reference/index.html#groupmemberroles
+        """
+
+        if group_full_path is None:
+            raise GitlabGetError(
+                "Group Path must be provided when getting member roles",
+                404,
+            )
+
+        query = (
+            """
+        {
+          group(fullPath: \""""
+            + group_full_path
+            + """\") {
+            memberRoles {
+              nodes {
+                id
+                name
+              }
+            }
+          }
+        }
+        """
+        )
+        verbose(
+            f"Executing graphQl query to get Member Roles for Group '{group_full_path}'"
+        )
+        result = self.graphql.execute(query)
+
+        # Validate Group / MemberRoles exist
+        if (
+            result["group"] is not None
+            and result["group"]["memberRoles"] is not None
+            and result["group"]["memberRoles"]["nodes"] is not None
+        ):
+            member_role_nodes = result["group"]["memberRoles"]["nodes"]
+        else:
+            raise GitlabGetError(f"Failed to get Member Roles from instance: {query}")
+
+        return self._convert_result_to_member_roles(member_role_nodes)
 
     @functools.lru_cache()
-    def get_member_role_cached(
-        self, name_or_id: Union[int, str], group_id: Union[int, None]
-    ):
-        member_roles = self.get_member_roles_cached(group_id)
+    def _get_member_roles_from_instance_cached(self) -> List[Dict[str, str]]:
+        """Query GraphQL using Python Gitlab
+        https://python-gitlab.readthedocs.io/en/stable/api-usage-graphql.html
+
+        GET Member_Role via REST Api needs "Admin" on Dedicated/Self-Hosted
+
+        On Self-Hosted/Dedicated it is only possible to create Member Roles at an instance level, so we query at that
+        level and cache the result in order to save API calls when processing multiple Groups
+
+        List of custom roles can be retrieved via GraphQL endpoint with "Guest+"
+        https://gitlab.com/gitlab-org/gitlab/-/issues/511919#note_2287581884
+
+        https://docs.gitlab.com/ee/api/graphql/reference/index.html#groupmemberroles
+        """
+
+        query = """
+            {
+              memberRoles {
+                edges {
+                  node {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+            """
+        result = self.graphql.execute(query)
+
+        if (
+            result["memberRoles"] is not None
+            and result["memberRoles"]["edges"] is not None
+        ):
+            member_role_edges = result["memberRoles"]["edges"]
+        else:
+            raise GitlabGetError(f"Failed to get Member Roles from instance: {query}")
+
+        member_role_nodes = []
+
+        for edge in member_role_edges:
+            member_role_nodes.append(edge["node"])
+
+        return self._convert_result_to_member_roles(member_role_nodes)
+
+    @staticmethod
+    def _convert_result_to_member_roles(
+        member_role_nodes: List[Dict[str, str]]
+    ) -> List[Dict[str, str]]:
+        # Unwrap Ids from GraphQl Gids
+        member_role_id_prefix = "gid://gitlab/MemberRole/"
+
+        member_roles = []
+        for node in member_role_nodes:
+            member_role_id = node["id"]
+            member_role_id = member_role_id.replace(member_role_id_prefix, "")
+            member_roles.append({"id": member_role_id, "name": node["name"]})
+
+        return member_roles
+
+    @staticmethod
+    def _get_member_role_from_member_roles(
+        name_or_id: Union[int, str], member_roles: List[Dict[str, str]]
+    ) -> Dict[str, str]:
         for member_role in member_roles:
-            if member_role["id"] == name_or_id:
+            member_role_id: str = member_role["id"]
+            member_role_name: str = member_role["name"]
+            if int(member_role_id) == name_or_id:
                 return member_role
-            elif (
-                type(name_or_id) == str
-                and member_role["name"].lower() == name_or_id.lower()
-            ):
+            elif member_role_name.lower() == str(name_or_id).lower():
                 return member_role
 
         # Failed to find member role so throw an exception explaining such to user
@@ -97,16 +228,27 @@ class PythonGitlab(Gitlab):
             404,
         )
 
-    @functools.lru_cache()
     def get_member_role_id_cached(
-        self, name_or_id: Union[int, str], group_id: Union[int, None]
+        self, name_or_id: Union[int, str], group_full_path: str
     ) -> int:
+        """
+        GETs a member role id set in the config by the Name of the Member Role (by calling out to API) or by Id
+
+        Get member_roles calls themselves are Cached, the logic in this method otherwise performs no API calls,
+        so we should not cache the result of this specific method, otherwise we may fill the cache with duplicate data
+        """
         if type(name_or_id) is int:
             # Already supplied as an id so no need to go get it from API
             return name_or_id
-        member_role = self.get_member_role_cached(name_or_id, group_id)
-        return member_role["id"]
 
-    @functools.lru_cache()
-    def is_gitlab_saas(self) -> bool:
+        if self._is_gitlab_saas():
+            member_roles = self._get_member_roles_from_group_cached(group_full_path)
+        else:
+            member_roles = self._get_member_roles_from_instance_cached()
+
+        member_role = self._get_member_role_from_member_roles(name_or_id, member_roles)
+
+        return int(member_role["id"])
+
+    def _is_gitlab_saas(self) -> bool:
         return self.url == gitlab.const.DEFAULT_URL

--- a/gitlabform/gitlab/python_gitlab.py
+++ b/gitlabform/gitlab/python_gitlab.py
@@ -146,7 +146,7 @@ class PythonGitlab(Gitlab):
         ):
             member_role_nodes = result["group"]["memberRoles"]["nodes"]
         else:
-            raise GitlabGetError(f"Failed to get Member Roles from instance: {query}")
+            raise GitlabGetError(f"Failed to get Member Roles from Group: {query}")
 
         return self._convert_result_to_member_roles(member_role_nodes)
 

--- a/gitlabform/gitlab/python_gitlab.py
+++ b/gitlabform/gitlab/python_gitlab.py
@@ -11,8 +11,9 @@ from gitlab.v4.objects import Group, Project
 
 # Extends the python-gitlab class to add convenience wrappers for common functionality used within gitlabform
 class PythonGitlab(Gitlab):
-    def get_user_id(self, username) -> int:
-        user = self.get_user_by_username_cached(username)
+    @functools.lru_cache()
+    def get_user_id_cached(self, username) -> int:
+        user = self._get_user_by_username_cached(username)
         return user.id
 
     def get_group_id(self, groupname) -> int:
@@ -41,7 +42,7 @@ class PythonGitlab(Gitlab):
 
     #  Uses "LIST" to get a user by username, to get the full User object, call get using the user's id
     @functools.lru_cache()
-    def get_user_by_username_cached(self, username: str) -> RESTObject:
+    def _get_user_by_username_cached(self, username: str) -> RESTObject:
         # Gitlab API will only ever return 0 or 1 entry when GETting using `username` attribute
         # https://docs.gitlab.com/ee/api/users.html#for-non-administrator-users
         # so will always be list[RESTObject] and never RESTObjectList from python-gitlab's api

--- a/gitlabform/processors/group/group_members_processor.py
+++ b/gitlabform/processors/group/group_members_processor.py
@@ -208,7 +208,7 @@ class GroupMembersProcessor(AbstractProcessor):
                     )
                     if member_role_id_or_name:
                         member_role_id_to_set = self.gl.get_member_role_id_cached(
-                            member_role_id_or_name, group.get_id()
+                            member_role_id_or_name, group.full_path
                         )
                     else:
                         member_role_id_to_set = None

--- a/gitlabform/processors/project/branches_processor.py
+++ b/gitlabform/processors/project/branches_processor.py
@@ -1,12 +1,14 @@
+from logging import debug
 from typing import Optional
-from logging import debug, info
-from cli_ui import warning, fatal
-from gitlab.v4.objects import Project, ProjectProtectedBranch
+from cli_ui import warning, fatal, debug as verbose
 from gitlab import (
     GitlabGetError,
     GitlabDeleteError,
     GitlabCreateError,
 )
+from gitlab.v4.objects import Project, ProjectProtectedBranch
+
+from gitlabform import gitlab
 from gitlabform.constants import EXIT_INVALID_INPUT, EXIT_PROCESSING_ERROR
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -123,13 +125,16 @@ class BranchesProcessor(AbstractProcessor):
         or group name but GitLab only supports their id. This method will transform the
         config by replacing them with ids.
         """
+        verbose("Transforming User and Group names in Branch configuration to Ids")
 
         for key in branch_config:
             if isinstance(branch_config[key], list):
                 for item in branch_config[key]:
                     if isinstance(item, dict):
                         if "user" in item:
-                            item["user_id"] = self.gl.get_user_id(item.pop("user"))
+                            item["user_id"] = self.gl.get_user_id_cached(
+                                item.pop("user")
+                            )
                         elif "group" in item:
                             item["group_id"] = self.gl.get_group_id(item.pop("group"))
 

--- a/gitlabform/processors/project/members_processor.py
+++ b/gitlabform/processors/project/members_processor.py
@@ -132,14 +132,9 @@ class MembersProcessor(AbstractProcessor):
                     users[user]["member_role"] if "member_role" in users[user] else None
                 )
                 if member_role_id_or_name:
-                    # For self-managed member_roles are at an instance level, for SaaS on a Group level
-                    if self.gl.is_gitlab_saas():
-                        group_id = project.namespace["id"]
-                    else:
-                        group_id = None
-
+                    group_name_and_path = project.namespace["full_path"]
                     member_role_id = self.gl.get_member_role_id_cached(
-                        member_role_id_or_name, group_id
+                        member_role_id_or_name, group_name_and_path
                     )
                 else:
                     member_role_id = None

--- a/gitlabform/processors/project/members_processor.py
+++ b/gitlabform/processors/project/members_processor.py
@@ -1,7 +1,6 @@
-import gitlab
 from cli_ui import debug as verbose, warning, info, error
 from cli_ui import fatal
-from gitlab import GitlabGetError
+from gitlab import GitlabGetError, GitlabDeleteError
 from gitlab.v4.objects import Project
 
 from gitlabform.constants import EXIT_INVALID_INPUT
@@ -114,7 +113,7 @@ class MembersProcessor(AbstractProcessor):
             for user in users:
                 info(f"Processing user '{user}'...")
                 try:
-                    user_id = self.gl.get_user_by_username_cached(user).get_id()
+                    user_id = self.gl.get_user_id_cached(user)
                 except GitlabGetError:
                     warning(f"Could not find user '{user}' in Gitlab, skipping...")
                     continue
@@ -224,20 +223,24 @@ class MembersProcessor(AbstractProcessor):
                     f"Removing user '{user_not_in_config}' that is not configured to be a member."
                 )
                 try:
-                    cached_user_id = self.gl.get_user_by_username_cached(
-                        user_not_in_config
-                    ).get_id()
-                    project.members.delete(id=cached_user_id)
-                except gitlab.GitlabGetError:
+                    user_id = self.gl.get_user_id_cached(user_not_in_config)
+                except GitlabGetError:
                     # User does not exist an instance level but is for whatever reason present on a Group/Project
                     # We should raise error into Logs but not prevent the rest of GitLabForm from executing
                     # This error is more likely to be prevalent in Dedicated instances; it is unlikely for a User to
                     # be completely deleted from gitlab.com
-                    error(
+                    warning(
                         f"Could not find User '{user_not_in_config}' on the Instance so can not remove User from Project '{project_and_group}'"
                     )
-                    pass
+                    continue
 
+                try:
+                    project.members.delete(id=user_id)
+                except GitlabDeleteError as delete_error:
+                    error(
+                        f"Member '{user_not_in_config}' could not be deleted: {delete_error}"
+                    )
+                    raise delete_error
         else:
             verbose("Not enforcing user members.")
 

--- a/gitlabform/processors/project/tags_processor.py
+++ b/gitlabform/processors/project/tags_processor.py
@@ -1,5 +1,5 @@
 from logging import debug
-from cli_ui import warning, fatal
+from cli_ui import warning, fatal, error
 
 from gitlabform.constants import EXIT_PROCESSING_ERROR
 from gitlabform.gitlab import GitLab
@@ -35,16 +35,30 @@ class TagsProcessor(AbstractProcessor):
                             elif "user_id" in config:
                                 user_ids.add(config["user_id"])
                             elif "user" in config:
-                                gitlab_user = self.gl.get_user_by_username_cached(
-                                    config["user"]
-                                )
-                                user_ids.add(gitlab_user.get_id())
+                                try:
+                                    user_id = self.gl.get_user_id_cached(config["user"])
+                                except GitlabGetError as e:
+                                    error(
+                                        f"Could not find User '{config["user"]}' on the Instance, cannot Protect "
+                                        f"Tag with them"
+                                    )
+                                    raise e
+
+                                user_ids.add(user_id)
                             elif "group_id" in config:
                                 group_ids.add(config["group_id"])
                             elif "group" in config:
-                                gitlab_group = self.gl.get_group_by_path_cached(
-                                    config["group"]
-                                )
+                                try:
+                                    gitlab_group = self.gl.get_group_by_path_cached(
+                                        config["group"]
+                                    )
+                                except GitlabGetError as e:
+                                    error(
+                                        f"Could not find Group '{config["group"]}' on the Instance, cannot Protect "
+                                        f"Tag with them"
+                                    )
+                                    raise e
+
                                 group_ids.add(gitlab_group.get_id())
 
                         for val in access_levels:

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "mergedeep==1.3.4",
         "packaging==24.2",
         "python-gitlab==5.3.0",
+        "python-gitlab[graphql]==5.3.0",
         "requests==2.32.3",
         "ruamel.yaml==0.17.21",
         "types-requests==2.32.0.20241016",


### PR DESCRIPTION
- graph ql GET only needs Guest+ permissions
- REST requires significantly higher permission sets which not all users maybe comfortable running with
- better error handling for missing Users