### PR TITLE
refactor: update 'project_settings_processor' to use python-gitlab

### DIFF
--- a/gitlabform/gitlab/projects.py
+++ b/gitlabform/gitlab/projects.py
@@ -126,21 +126,6 @@ class GitLabProjects(GitLabCore):
         except NotFoundException:
             return dict()
 
-    def put_project_settings(self, project_and_group_name, project_settings):
-        # project_settings has to be like this:
-        # {
-        #     'setting1': value1,
-        #     'setting2': value2,
-        # }
-        # ..as documented at: https://docs.gitlab.com/ce/api/projects.html#edit-project
-        return self._make_requests_to_api(
-            "projects/%s",
-            project_and_group_name,
-            "PUT",
-            data=None,
-            json=project_settings,
-        )
-
     def get_groups_from_project(self, project_and_group_name):
         # couldn't find an API call that was giving me directly
         # the shared groups, so I'm using directly the GET /projects/:id call

--- a/gitlabform/processors/project/project_settings_processor.py
+++ b/gitlabform/processors/project/project_settings_processor.py
@@ -1,12 +1,28 @@
+from logging import debug
+
 from gitlabform.gitlab import GitLab
-from gitlabform.processors.single_entity_processor import SingleEntityProcessor
+from gitlabform.processors.abstract_processor import AbstractProcessor
+
+from gitlab.v4.objects import Project
 
 
-class ProjectSettingsProcessor(SingleEntityProcessor):
+class ProjectSettingsProcessor(AbstractProcessor):
     def __init__(self, gitlab: GitLab):
-        super().__init__(
-            "project_settings",
-            gitlab,
-            get_method_name="get_project_settings",
-            edit_method_name="put_project_settings",
-        )
+        super().__init__("project_settings", gitlab)
+
+    def _process_configuration(self, project_path: str, configuration: dict):
+        debug("Processing project settings...")
+        project: Project = self.gl.get_project_by_path_cached(project_path)
+
+        project_settings_in_config = configuration.get("project_settings", {})
+        project_settings_in_gitlab = project.asdict()
+
+        if self._needs_update(project_settings_in_gitlab, project_settings_in_config):
+            debug("Updating project settings")
+            for key, value in project_settings_in_config.items():
+                debug(f"Updating setting {key} to value {value}")
+                setattr(project, key, value)
+
+            project.save()
+        else:
+            debug("No update needed for project settings")

--- a/gitlabform/processors/project/project_settings_processor.py
+++ b/gitlabform/processors/project/project_settings_processor.py
@@ -35,7 +35,6 @@ class ProjectSettingsProcessor(AbstractProcessor):
             debug("No update needed for project settings")
 
     def get_project_settings(self, project_path: str):
-        # return self.get_entity_in_gitlab(project_path)
         return self.gl.get_project_by_path_cached(project_path).asdict()
 
     def _print_diff(

--- a/gitlabform/processors/project/project_settings_processor.py
+++ b/gitlabform/processors/project/project_settings_processor.py
@@ -1,7 +1,8 @@
 from logging import debug
-
+from typing import Callable
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
+from gitlabform.processors.util.difference_logger import DifferenceLogger
 
 from gitlab.v4.objects import Project
 
@@ -9,6 +10,7 @@ from gitlab.v4.objects import Project
 class ProjectSettingsProcessor(AbstractProcessor):
     def __init__(self, gitlab: GitLab):
         super().__init__("project_settings", gitlab)
+        self.get_entity_in_gitlab: Callable = getattr(self, "get_project_settings")
 
     def _process_configuration(self, project_path: str, configuration: dict):
         debug("Processing project settings...")
@@ -16,13 +18,34 @@ class ProjectSettingsProcessor(AbstractProcessor):
 
         project_settings_in_config = configuration.get("project_settings", {})
         project_settings_in_gitlab = project.asdict()
+        debug(project_settings_in_gitlab)
+        debug(f"project_settings BEFORE: ^^^")
 
         if self._needs_update(project_settings_in_gitlab, project_settings_in_config):
             debug("Updating project settings")
             for key, value in project_settings_in_config.items():
                 debug(f"Updating setting {key} to value {value}")
                 setattr(project, key, value)
-
             project.save()
+
+            debug(project.asdict())
+            debug(f"project_settings AFTER: ^^^")
+
         else:
             debug("No update needed for project settings")
+
+    def get_project_settings(self, project_path: str):
+        # return self.get_entity_in_gitlab(project_path)
+        return self.gl.get_project_by_path_cached(project_path).asdict()
+
+    def _print_diff(
+        self, project_or_project_and_group: str, entity_config, diff_only_changed: bool
+    ):
+        entity_in_gitlab = self.get_project_settings(project_or_project_and_group)
+
+        DifferenceLogger.log_diff(
+            f"{self.configuration_name} changes",
+            entity_in_gitlab,
+            entity_config,
+            only_changed=diff_only_changed,
+        )


### PR DESCRIPTION
This PR refactors the code so that `project_settings` config is processed using python-gitlab library.

By moving the processor from `SingleEntityProcessor` to  `AbstractProcessor`, the change is made easily. But it looses the "diff print", which logs the configs as before vs after. I suppose that could be viewed as blocker for this PR.

The diff logging hasn't been globally supported for all the processors. I imagine it can re-implemented differently to support all processors, but that's a bigger task and probably should be done separately.

closes #927 
