### PR TITLE
chore: update base image to Alpine 3.21

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,6 +1,4 @@
-FROM python:3.12-alpine3.18
-COPY --from=pandoc/core:2 /usr/bin/pandoc* /usr/bin/
-COPY --from=pandoc/core:2 /usr/lib/libffi* /usr/lib/
+FROM python:3.12-alpine3.21
 RUN apk add --no-cache \
     gmp \
     lua5.3 \

--- a/dev/tests.Dockerfile
+++ b/dev/tests.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine3.18
+FROM python:3.12-alpine3.21
 
 COPY ../setup.py /gitlabform/
 COPY ../README.md /gitlabform/


### PR DESCRIPTION
* Python images based on Alpine 3.18 are unmaintained (last update: 2024-04-09)
* Thus we should switch to images based on Alpine 3.21