### PR TITLE
chore(ci): configure dependabot to group python-gitlab packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      python-gitlab:
+        patterns:
+          - "python-gitlab"


### PR DESCRIPTION
There are currently 2 packages required from python -gitlab. Dependabot opens separate PR for updating their versions but they fail to install due to conflicts. See issue #934.

This change updates the config so that python-gitlab packages are updated together in a single PR. That should help us easily stay up-to-date with newer release of that package, without needing to manually perform update.

closes #934