### PR TITLE
chore(ci): fix dependabot config group package pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,4 @@ updates:
     groups:
       python-gitlab:
         patterns:
-          - "python-gitlab"
+          - "python-gitlab*"


### PR DESCRIPTION
I think the previous attempt in #935 for grouping python-gitlab packages together by dependabot PR was incomplete. I re-triggered dependabot but it didn't seem to resolve the issue mentioned in #934. I suspect the pattern for selecting which packages to be groped was not correct.

This PR uses a glob pattern instead of a static string to specify that python-gitlab packages should be grouped together. Not sure how to test this though without going through reproducing the issue elsewhere and testing the fix, which is kind of a lot of work.
