### PR TITLE
fix: skip_groups doesn't work for subgroup

### DIFF
--- a/gitlabform/configuration/groups.py
+++ b/gitlabform/configuration/groups.py
@@ -41,6 +41,10 @@ class ConfigurationGroups(ConfigurationCommon, ABC):
         :param group: "group_name"
         :return: merged configuration for this group, from common, group. Merging is additive.
         """
+        # Check if group must be skipped
+        if self.is_group_skipped(group):
+            debug(f"Group {group} is skipped, returning empty config")
+            return {}
 
         common_config = self.get_common_config()
         debug("*Effective* common config: %s", to_str(common_config))

--- a/tests/unit/configuration/test_skip_groups_skip_projects.py
+++ b/tests/unit/configuration/test_skip_groups_skip_projects.py
@@ -85,3 +85,36 @@ def test__config_skip_group(group, is_skipped, request):
         configuration_for_skip_groups_skip_projects.is_group_skipped(group)
         == is_skipped
     )
+
+
+def test__config_skip_group_configuration():
+    config_yaml = """
+    ---
+    projects_and_groups:
+      "*":
+        group_settings:
+          default: setting
+      "parent-group/*":
+        group_settings:
+          specific: setting
+
+    skip_groups:
+    - parent-group/skip-group/*
+    """
+
+    configuration = Configuration(config_string=config_yaml)
+
+    normal_config = configuration.get_effective_config_for_group(
+        "parent-group/normal-group"
+    )
+    assert normal_config.get("group_settings", {}).get("specific") == "setting"
+
+    skipped_config = configuration.get_effective_config_for_group(
+        "parent-group/skip-group"
+    )
+    assert skipped_config == {}
+
+    skipped_subgroup_config = configuration.get_effective_config_for_group(
+        "parent-group/skip-group/subgroup"
+    )
+    assert skipped_subgroup_config == {}


### PR DESCRIPTION
I discovered that `skip_groups` doesn't work for subgroups. I saw that there is also an open issue.

This PR should fix this.

### Checklist

- [X] Tests have been added
- [X] Commits are signed with Developer Certificate of Origin

Fixes #275