### PR TITLE
fix: project topics should not be removed if topics are not in the config

### DIFF
--- a/gitlabform/processors/project/project_settings_processor.py
+++ b/gitlabform/processors/project/project_settings_processor.py
@@ -59,6 +59,9 @@ class ProjectSettingsProcessor(AbstractProcessor):
     ) -> None:
         project_settings_topics: Dict = project_settings_in_config.get("topics", [])
 
+        if not project_settings_topics:
+            return
+
         keep_existing: bool = False
 
         for i, topic in enumerate(project_settings_topics):

--- a/tests/acceptance/standard/test_project_settings.py
+++ b/tests/acceptance/standard/test_project_settings.py
@@ -21,6 +21,31 @@ class TestProjectSettings:
         updated_project: Project = gl.projects.get(project.id)
         assert updated_project.visibility == "internal"
 
+    def test__edit_project_settings_topics_default_no_topics_config(
+        self, gl: Gitlab, project: Project
+    ) -> None:
+        """
+        Test that the topics are not changed when no topics are specified in the config
+        """
+        project.topics = ["topicA", "topicB"]
+        project.save()
+
+        config: str = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            project_settings:
+              visibility: internal
+        """
+
+        run_gitlabform(config, project)
+
+        updated_project: Project = gl.projects.get(project.id)
+        project_topics: List[str] = updated_project.topics
+
+        assert len(project_topics) == 2
+        assert "topicA" in project_topics
+        assert "topicB" in project_topics
+
     def test__edit_project_settings_topics_default(
         self, gl: Gitlab, project: Project
     ) -> None:


### PR DESCRIPTION
If the `project_settings` config does not specify `topics` attribute, any topics added manually are being removed. This is bug introduced in v4.1.2. This change reproduces the bug and fixes it so that manually managed topics configs are not removed.

fixes #946 
