### PR TITLE
refactor: migrate 'merge_requests_approvals' processor to python-gitlab

### DIFF
--- a/gitlabform/gitlab/project_merge_requests_approvals.py
+++ b/gitlabform/gitlab/project_merge_requests_approvals.py
@@ -5,21 +5,6 @@ from gitlabform.gitlab.core import (
 
 
 class GitLabProjectMergeRequestsApprovals(GitLabCore):
-    # configuration
-
-    def get_approvals_settings(self, project_and_group_name):
-        pid = self._get_project_id(project_and_group_name)
-        return self._make_requests_to_api("projects/%s/approvals", pid)
-
-    def post_approvals_settings(self, project_and_group_name, data):
-        # for this endpoint GitLab still actually wants pid, not "group/project"...
-        pid = self._get_project_id(project_and_group_name)
-        data_required = {"id": pid}
-        data = {**data, **data_required}
-        self._make_requests_to_api(
-            "projects/%s/approvals", pid, "POST", data, expected_codes=201
-        )
-
     # approval rules
 
     def get_approval_rules(self, project_and_group_name):

--- a/gitlabform/processors/project/merge_requests_approvals.py
+++ b/gitlabform/processors/project/merge_requests_approvals.py
@@ -1,17 +1,44 @@
-from cli_ui import fatal
+from cli_ui import fatal, debug
+from typing import Callable
+from gitlab.v4.objects import Project
 
 from gitlabform.gitlab import GitLab
-from gitlabform.processors.single_entity_processor import SingleEntityProcessor
+from gitlabform.processors.abstract_processor import AbstractProcessor
+from gitlabform.processors.util.difference_logger import DifferenceLogger
 
 
-class MergeRequestsApprovals(SingleEntityProcessor):
+class MergeRequestsApprovals(AbstractProcessor):
     def __init__(self, gitlab: GitLab):
-        super().__init__(
-            "merge_requests_approvals",
-            gitlab,
-            get_method_name="get_approvals_settings",
-            edit_method_name="post_approvals_settings",
+        super().__init__("merge_requests_approvals", gitlab)
+        self.get_entity_in_gitlab: Callable = getattr(
+            self, "get_project_mr_approvals_settings"
         )
+
+    def _process_configuration(self, project_path: str, configuration: dict) -> None:
+        debug("Processing project merge requests approvals settings...")
+        project: Project = self.gl.get_project_by_path_cached(project_path)
+
+        mr_approval_settings_in_config: dict = configuration.get(
+            "merge_requests_approvals", {}
+        )
+        mr_approval_settings_in_gitlab: dict = project.approvals.get().asdict()
+
+        debug(mr_approval_settings_in_gitlab)
+        debug("merge_requests_approvals BEFORE: ^^^")
+
+        if self._needs_update(
+            mr_approval_settings_in_gitlab, mr_approval_settings_in_config
+        ):
+            debug("Updating project merge requests approvals settings")
+            project.approvals.update(**mr_approval_settings_in_config)
+
+            debug(project.approvals.get().asdict())
+            debug("merge_requests_approvals AFTER: ^^^")
+        else:
+            debug("No update needed for project merge requests approvals settings")
+
+    def get_project_mr_approvals_settings(self, project_path: str):
+        return self.gl.get_project_by_path_cached(project_path).approvals.get().asdict()
 
     def _can_proceed(self, project_or_group: str, configuration: dict):
         if "approvals_before_merge" in configuration["merge_requests_approvals"]:
@@ -22,3 +49,18 @@ class MergeRequestsApprovals(SingleEntityProcessor):
             )
         else:
             return True
+
+    # TODO: duplicated logic with project_settings_processor.py. Should be refactored - ideally in the AbstractProcessor
+    def _print_diff(
+        self, project_or_project_and_group: str, entity_config, diff_only_changed: bool
+    ):
+        entity_in_gitlab = self.get_project_mr_approvals_settings(
+            project_or_project_and_group
+        )
+
+        DifferenceLogger.log_diff(
+            f"{self.configuration_name} changes",
+            entity_in_gitlab,
+            entity_config,
+            only_changed=diff_only_changed,
+        )


### PR DESCRIPTION
This PR refactors the logic that processes `merge_requests_approvals` section in a config for managing a project's MR approval settings. The code has been refactored to use python-gitlab as part of the effort of moving the project to use that library instead of relying on homegrown logic.

closes #928 