### PR TITLE
tests: stablize intermittent failure from TestFiles acceptance tests

### DIFF
--- a/tests/acceptance/standard/test_files.py
+++ b/tests/acceptance/standard/test_files.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import time
 
 from gitlab import GitlabGetError
 
@@ -158,7 +159,12 @@ class TestFiles:
         project_file = project.files.get(ref="main", file_path="README.md")
         assert project_file.decode().decode("utf-8") == DEFAULT_README
 
-        # check if no_access_branch stays protected after the file update
+        # Retry mechanism to check if no_access_branch stays protected after the file update
+        for _ in range(5):
+            branch = project.branches.get(no_access_branch.name)
+            if branch.protected:
+                break
+            time.sleep(2)
         assert branch.protected is True
 
     def test__delete_file_protected_branch(self, project, branch):


### PR DESCRIPTION
The acceptance test case named `test__set_file_strongly_protected_branch` in `TestFiles` class has been unstable for a few months. This affects the CI process. Most PRs randomly fails because of failure from this test case. This impacts the stability of the project development - can be confusing for contributors when unrelated failures like this occurs.

The failure occurs when the test attempts to validate if a protected branch remains protected after a file update in that branch is performed. I suspect the reason is the tests are running against a GitLab environment running in a container. Either due to resources or GitLab's updates, protecting a branch takes longer than it did before. That's why assertion fails to validate that the branch remains protected.

The change in this PR adds a small retry logic in the above mentioned test. It'll retry the assertion about 5 times and wait 2 seconds in between. I tested it locally by running the tests 10 times using following command:

```sh
pytest --count=10 tests/acceptance/standard/test_files.py::TestFiles::test__set_file_strongly_protected_branch
```

Without the proposed change in this PR, the test fails 4 out of 10 times. With the change in this PR, the test passes every time, although I imagine it depends on how much resource is available in the container where GitLab runs.

fixes #944 
