### PR TITLE
feat: add support for 'Planner' role

### DIFF
--- a/gitlabform/gitlab/__init__.py
+++ b/gitlabform/gitlab/__init__.py
@@ -28,6 +28,7 @@ class AccessLevel(enum.IntEnum):
     NO_ACCESS = 0
     MINIMAL = 5  # introduced in GitLab 13.5
     GUEST = 10
+    PLANNER = 15  # introduced in GitLab 17.7
     REPORTER = 20
     DEVELOPER = 30
     MAINTAINER = 40


### PR DESCRIPTION
This PR adds support for a new out-of-the-box role introduced by GitLab in version 17.7. The role is named 'Planner'.

Added a new enum in the GitLabForm's access level so that the new role can be used or referenced in the gitlabform config.

Docs:
- [GitLab's roles](https://docs.gitlab.com/user/permissions/#roles)
- [GitLab's access level values](https://docs.gitlab.com/api/access_requests/#valid-access-levels)

fixes #980 
