### PR TITLE
docs: fix changelog for v4.2.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,30 +7,25 @@
 * Add the possibility to add group level webhooks [#919](https://github.com/gitlabform/gitlabform/pull/919), [szEvEz](https://github.com/szEvEz)
 * Add Project Security Settings support [#922](https://github.com/gitlabform/gitlabform/pull/922), [szEvEz](https://github.com/szEvEz)
 
-### Bug Fixes
-
-* Project topics should not be removed if topics are not in the config [#954](https://github.com/gitlabform/gitlabform/pull/954), [amimas](https://github.com/amimas)
-
-### Refactors
-
-* migrate 'merge_requests_approvals' processor to python-gitlab [#955](https://github.com/gitlabform/gitlabform/pull/955), [amimas](https://github.com/amimas)
-
 ### Tests
 
-* Stabilize intermittent failure from TestFiles acceptance tests [#956](https://github.com/gitlabform/gitlabform/pull/956), [amimas](https://github.com/amimas)
+* Get rid of warnings about unregistered test markers [gdubicki](https://github.com/gdubicki)
 * Handle flaky test in test_files [#961](https://github.com/gitlabform/gitlabform/pull/961), [gdubicki](https://github.com/gdubicki)
-* Dix issues with eventual consistency in tests and cover an mr_approval_rules use case [#969](https://github.com/gitlabform/gitlabform/pull/969), [TimKnight-DWP](https://github.com/TimKnight-DWP)
+* Fix issues with eventual consistency in tests and cover an mr_approval_rules use case [#969](https://github.com/gitlabform/gitlabform/pull/969), [TimKnight-DWP](https://github.com/TimKnight-DWP)
+
 
 ### Documentation
 
 * Improving the Features listings and local dev instructions, [gdubicki](https://github.com/gdubicki)
+* Correct info on how to run a single test method [gdubicki](https://github.com/gdubicki)
 
 ### Code Style
 
 * Implement `black` formatting [#959](https://github.com/gitlabform/gitlabform/pull/959), [gdubicki](https://github.com/gdubicki)
 
-### Build Process
+### Build / CI
 
+* CI: separate steps of starting GitLab in Docker and running acceptance tests [gdubicki](https://github.com/gdubicki)
 * Improved pyproject.toml [#945](https://github.com/gitlabform/gitlabform/pull/945), [gdubicki](https://github.com/gdubicki)
 * Ensure that the app keeps running on MacOS and Windows [#958](https://github.com/gitlabform/gitlabform/pull/958), [gdubicki](https://github.com/gdubicki)
 


### PR DESCRIPTION
This PR fixes the changelog for v4.2.0. Original changelog had some duplicate information from prior version and also missed some other entries. Updates from this PR should make it more accurate.

After this PR is merged, we should manually copy/paste the updated changelog to existing github release details: https://github.com/gitlabform/gitlabform/releases/tag/v4.2.0

