### PR TITLE
fix: improve logging for labels processor

### DIFF
--- a/gitlabform/processors/util/labels_processor.py
+++ b/gitlabform/processors/util/labels_processor.py
@@ -1,8 +1,6 @@
-from cli_ui import debug as verbose, info, error
+from cli_ui import debug as verbose, info
 from typing import Dict, List, Callable
 
-from gitlab import GitlabGetError
-from gitlab.base import RESTObject
 from gitlab.v4.objects import Group, Project, ProjectLabel, GroupLabel
 
 


### PR DESCRIPTION
We have some errors in our gitlab form logging with verbose on:

```
Processing section 'group_labels'
Warning: Error occurred while processing group dwp/secure-development, exception:
404: 404 Label Not Found
```

There's nothing there for us to use to identify the problematic label.

This MR adds one extra verbose log line to assist with identification and ensures labels_processor respects "Verbose" setting by using the cli_ui utility not logging