### PR TITLE
test: fix test case for job token scope

### DIFF
--- a/docs/reference/job_token_scope.md
+++ b/docs/reference/job_token_scope.md
@@ -1,16 +1,29 @@
 # CI/CD job token scope
 
 ## Project CI/CD job token scope
-This section purpose is to manage the [project CI/CD job token scope](https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html#control-job-token-access-to-your-project)
+This section's purpose is to manage the [project CI/CD job token scope](https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html#control-job-token-access-to-your-project).
 
+The GitLab UI refers to this setting under "Authorized groups and projects". This controls which projects can use CI/CD job tokens to authenticate with the current project.
 
-The values are like documented at [Job Token Scope API docs](https://docs.gitlab.com/ee/api/project_job_token_scopes.html), **except the Enabled**.
+There are two main options in the UI:
+*   **All groups and projects**: This option disables any restrictions, allowing any project to use a job token to access this project. This corresponds to the API field `inbound_enabled` being `false`.
+*   **Only this project and any groups and projects in the allowlist**: This option restricts access to only the current project and those explicitly added to the allowlist. This corresponds to the API field `inbound_enabled` being `true`.
 
-We use `limit_access_to_this_project` as the variable name for restricting access to the Project from other projects, rather than `inbound_enabled` in the GET and `enabled` in the PATCH requests defined in the api, in line with GitLab's UI and [intended language](https://docs.gitlab.com/ee/update/deprecations.html#default-cicd-job-token-ci_job_token-scope-changed-1).
+It's important to note that this project-level setting can only be controlled if the instance-level setting `enforce_ci_inbound_job_token_scope_enabled` is disabled. This instance setting requires admin privileges to change.
 
-You can:
+In `gitlabform`, we use the `limit_access_to_this_project` setting to control the "Authorized groups and projects" option. Setting `limit_access_to_this_project: true` enables the restriction ("Only this project and any groups and projects in the allowlist"), while `limit_access_to_this_project: false` disables it ("All groups and projects").
 
-* [Limit access to a project](https://docs.gitlab.com/ee/api/project_job_token_scopes.html#patch-a-projects-cicd-job-token-access-settings)
+The [Job Token Scope API docs](https://docs.gitlab.com/ee/api/project_job_token_scopes.html) use `inbound_enabled` in GET requests and `enabled` in PATCH requests, which can be confusing. The `gitlabform` `limit_access_to_this_project` setting maps to the API's `enabled` field in PATCH requests.
+
+In addition to the main setting, you can manage the project's CI/CD job token allowlist. This allowlist determines which other projects and groups are authorized to use their job tokens to access this project when the "Only this project and any groups and projects in the allowlist" option is enabled.
+
+Within the `allowlist` section of the configuration, you can use the `enforce` setting:
+
+*   When `enforce: true` is set, `gitlabform` will ensure that the allowlist in GitLab exactly matches the `projects` and `groups` specified in your configuration. Any projects or groups found in the GitLab allowlist that are *not* listed in your `gitlabform` configuration will be removed.
+*   If `enforce` is not set or set to `false`, `gitlabform` will only add the projects and groups specified in the configuration to the allowlist, leaving any existing entries in GitLab untouched.
+
+You can add projects and groups to the allowlist using their ID or path/name:
+
 * [Add other projects to the job token allowlist](https://docs.gitlab.com/ee/api/project_job_token_scopes.html#add-a-project-to-a-cicd-job-token-inbound-allowlist)
 * [Add groups to the job token allowlist](https://docs.gitlab.com/ee/api/project_job_token_scopes.html#add-a-group-to-a-cicd-job-token-allowlist)
 

--- a/tests/acceptance/standard/test_job_token_scope.py
+++ b/tests/acceptance/standard/test_job_token_scope.py
@@ -48,17 +48,7 @@ class TestProjectJobTokenScope:
         # Setup: Disable instance-level enforcement to allow project-level configuration
         instance_settings = gl.settings.get()
         instance_settings.enforce_ci_inbound_job_token_scope_enabled = False
-
-        # Retry settings update in case of temporary resource issues
-        max_retries = 3
-        for attempt in range(max_retries):
-            try:
-                instance_settings.save()
-                break
-            except Exception as e:
-                if attempt == max_retries - 1:
-                    raise Exception(f"Failed to update instance settings after {max_retries} attempts: {str(e)}")
-                print(f"Attempt {attempt + 1} failed, retrying...")
+        instance_settings.save()
 
         try:
             # Setup: Enable limit access at project level

--- a/tests/acceptance/standard/test_job_token_scope.py
+++ b/tests/acceptance/standard/test_job_token_scope.py
@@ -48,7 +48,7 @@ class TestProjectJobTokenScope:
         # Setup: Disable instance-level enforcement to allow project-level configuration
         instance_settings = gl.settings.get()
         instance_settings.enforce_ci_inbound_job_token_scope_enabled = False
-        
+
         # Retry settings update in case of temporary resource issues
         max_retries = 3
         for attempt in range(max_retries):


### PR DESCRIPTION
In a recent major release of GitLab (v18), the CI Job token scope
related setting introduced breaking changes. Going forward, the
option to configure 'limit access to this project' has been removed
and it's enabled by default. However, this option can be restored
by GitLab admin from an instance level setting.

See the [breaking change announcement](https://docs.gitlab.com/update/deprecations/?removal_milestone=18.0&breaking_only=true#cicd-job-token---authorized-groups-and-projects-allowlist-enforcement)
for more details.

After GitLab v18, the test case for gitlabform validating if the
setting mentioned above can be 'disabled', began to fail. This is
because the setting could no longer be configured. This change adds
necessary logic in the test case so that instance level setting is
updated to allow this test case to validate that the option can be
disabled.

In addition, job token scope related documentation has been updated for clarification.

fixes #1029