### PR TITLE
test: add acceptance test for group ldap links config processor

### DIFF
--- a/dev/gitlab.rb
+++ b/dev/gitlab.rb
@@ -18,6 +18,10 @@ gitlab_rails['ldap_servers'] = {
     'timeout' => 1
   }
 }
+# Important: disable login UI for AD-style login
+# Regular username/password based login will be used
+# for local development of gitlabform
+gitlab_rails['prevent_ldap_sign_in'] = true
 gitlab_rails['omniauth_enabled'] = true
 gitlab_rails['omniauth_allow_single_sign_on'] = ['saml']
 gitlab_rails['omniauth_block_auto_created_users'] = false

--- a/dev/gitlab.rb
+++ b/dev/gitlab.rb
@@ -3,6 +3,21 @@ registry['enable']=false
 prometheus_monitoring['enable']=false
 gitlab_rails['initial_license_file']='/etc/gitlab/Gitlab.gitlab-license'
 gitlab_kas['enable']=false
+gitlab_rails['ldap_enabled'] = true
+gitlab_rails['ldap_servers'] = {
+  'ldap_main' => {
+    'label' => 'LDAP Main',
+    'host' => 'localhost',
+    'port' => 389,
+    'uid' => 'uid',
+    'bind_dn' => 'cn=admin,dc=example,dc=org',
+    'password' => 'admin',
+    'encryption' => 'plain',
+    'base' => 'dc=example,dc=org',
+    'group_base' => 'ou=groups,dc=example,dc=org',
+    'timeout' => 1
+  }
+}
 gitlab_rails['omniauth_enabled'] = true
 gitlab_rails['omniauth_allow_single_sign_on'] = ['saml']
 gitlab_rails['omniauth_block_auto_created_users'] = false

--- a/tests/acceptance/premium/test_group_ldap_links.py
+++ b/tests/acceptance/premium/test_group_ldap_links.py
@@ -1,0 +1,38 @@
+import pytest
+
+from tests.acceptance import run_gitlabform
+from gitlabform.gitlab import AccessLevel
+from gitlab.exceptions import GitlabListError
+
+pytestmark = pytest.mark.requires_license
+
+
+class TestGroupLDAPLinks:
+    def test__add_ldap_links(self, gl, group):
+        """Test adding LDAP links to a group."""
+
+        # Verify that there are no existing LDAP links
+        # GitLab API returns 404 if there are no LDAP links configured.
+        # That's why expecting GitlabListError when trying to get the existing links.
+        with pytest.raises(GitlabListError):
+            group.ldap_group_links.list(get_all=True)
+
+        # Add LDAP links to the group using basic configuration
+        add_ldap_link = f"""
+        projects_and_groups:
+          {group.full_path}/*:              
+            group_ldap_links: 
+              devops_users:                                 
+                provider: LDAP Main
+                cn: devops
+                group_access: maintainer
+        """
+        run_gitlabform(add_ldap_link, group)
+
+        # Verify that the LDAP link was created
+        refreshed_group = gl.groups.get(group.id)
+        ldap_links = refreshed_group.ldap_group_links.list(get_all=True)
+        assert len(ldap_links) == 1
+        assert ldap_links[0].provider == "LDAP Main"
+        assert ldap_links[0].cn == "devops"
+        assert ldap_links[0].group_access == AccessLevel.get_value("maintainer")

--- a/tests/acceptance/premium/test_group_ldap_links.py
+++ b/tests/acceptance/premium/test_group_ldap_links.py
@@ -56,3 +56,67 @@ class TestGroupLDAPLinks:
         assert ldap_links[1].provider == "LDAP Main"
         assert ldap_links[1].filter == "(devType=security)"
         assert ldap_links[1].group_access == AccessLevel.get_value("developer")
+
+    def test__update_ldap_links(self, gl, group):
+        """Test updaing LDAP links of a group."""
+
+        # Verify group has 2 ldap links - last state of the group in previous test
+        assert len(group.ldap_group_links.list()) == 2
+
+        # Test 1: Update the 2 ldap links that were added to the group in previous test
+        update_group_ldap_settings = f"""
+        projects_and_groups:
+          {group.full_path}/*:              
+            group_ldap_links: 
+              devops_users:                                 
+                provider: LDAP Main
+                cn: devops
+                group_access: developer  # <-- Changed from 'maintainer'
+              security_users:                                 
+                provider: LDAP Main
+                filter: (devType=security)
+                group_access: reporter  # <-- Changed from 'developer'
+        """
+        run_gitlabform(update_group_ldap_settings, group)
+        # Verify that the LDAP link was updated
+        refreshed_group = gl.groups.get(group.id)
+        ldap_links = refreshed_group.ldap_group_links.list(get_all=True)
+        assert len(ldap_links) == 2
+
+        assert ldap_links[0].provider == "LDAP Main"
+        assert ldap_links[0].cn == "devops"
+        assert ldap_links[0].group_access == AccessLevel.get_value("developer")
+
+        assert ldap_links[1].provider == "LDAP Main"
+        assert ldap_links[1].filter == "(devType=security)"
+        assert ldap_links[1].group_access == AccessLevel.get_value("reporter")
+
+    def test__enforce_ldap_links(self, gl, group):
+        """Test enforce mode for LDAP links config of a group."""
+
+        # Verify group has 2 ldap links - last state of the group in previous test
+        assert len(group.ldap_group_links.list()) == 2
+
+        # Test: Previous test had configured 2 ldap links: devops_users, security_users
+        # Enable enforce mode and skip security_users in the config
+        # This should result in security_users being removed
+        enforce_ldap_settings = f"""
+        projects_and_groups:
+          {group.full_path}/*:              
+            group_ldap_links:
+              enforce: true 
+              devops_users:                                 
+                provider: LDAP Main
+                cn: devops
+                group_access: developer
+        """
+        run_gitlabform(enforce_ldap_settings, group)
+
+        # Verify result
+        refreshed_group = gl.groups.get(group.id)
+        ldap_links = refreshed_group.ldap_group_links.list(get_all=True)
+        assert len(ldap_links) == 1
+
+        assert ldap_links[0].provider == "LDAP Main"
+        assert ldap_links[0].cn == "devops"
+        assert ldap_links[0].group_access == AccessLevel.get_value("developer")


### PR DESCRIPTION
It seems we never had any acceptance tests for group ldap links. This PR adds some basic tests - could be expanded in future if needed. It can be helpful for debugging fixing ldap config related issues.

To enable ldap related API endpoints in GitLab for running the tests, gitlab's config needed to be updated by adding a dummy ldap server configuration. It doesn't need to be an active/real server - just the presence of the config is necessary for the relevant API to be available.

Disabled the option to allow login using ldap in the UI when the dev container is started up. This is to help avoid confusions during local development because ldap login becomes the default option and that won't work since there aren't any real ldap server in local dev mode.
