### PR TITLE
Update ci_cd_variables.md to include raw variable example

### DIFF
--- a/docs/reference/ci_cd_variables.md
+++ b/docs/reference/ci_cd_variables.md
@@ -45,6 +45,15 @@ projects_and_groups:
         value: "foobar-123-123-123"
         masked: true
 
+      # --- Adding/resetting non-expanded variable
+      # Gitlab's UI uses the term "expanded" while
+      # the API uses "raw".  Variables are not expanded
+      # when "raw" is true.
+      my_raw_variable:
+        key: RAW_VAR
+        value: "foobar-123-123-123"
+        raw: true
+
       # --- Adding/resetting variables per environment
       aws_access_key_id_for_deploying_in_production:
         key: APP_HOST_AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Gitlab's UI uses the term "expanded" when indicating whether "$ will be treated as the start of a reference to another variable" or not.  The API uses the term "raw" instead, which is confusing if you're not familiar with the API.  This adds an example, since the docs weren't clear they definitely supported this option.