### PR TITLE
feat: add support for duo_features_enabled at project_settings level

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -45,6 +45,7 @@ projects_and_groups:
       visibility: internal
       only_allow_merge_if_pipeline_succeeds: true
       only_allow_merge_if_all_discussions_are_resolved: true
+      duo_features_enabled: false
       container_expiration_policy_attributes:
         cadence: "1month"
         enabled: true
@@ -55,6 +56,11 @@ projects_and_groups:
         name_regex_keep: ".*-main"
       # (...)
 ```
+
+### Project Settings - GitLab Duo
+We have extended the functionality of GitLabForm to support setting `duo_features_enabled` at the Project Level, which are currently supported in the [Group Setting API](https://docs.gitlab.com/api/groups/#update-group-attributes), but only via GraphQL for Projects.
+
+You can specify `duo_features_enabled: true` or `false` under the `project_settings` configuration and GitLabForm will make the appropriate [GraphQL Mutation](https://gitlab.com/gitlab-org/gitlab/-/issues/571776) to update the Project Settings.
 
 ### Project Settings - Topics
 

--- a/gitlabform/processors/project/project_settings_processor.py
+++ b/gitlabform/processors/project/project_settings_processor.py
@@ -230,6 +230,10 @@ class ProjectSettingsProcessor(AbstractProcessor):
                     f"Failed to update duo_features_enabled for Project: {project.path_with_namespace}, to: {duo_features_enabled}: {result['errors']}"
                 )
         except TransportQueryError as e:
+            if e.errors is not None:
+                error_message = e.errors[0].message
+            else:
+                error_message = "Unknown GraphQL error"
             raise GitlabUpdateError(
-                f"Failed to update duo_features_enabled for Project: {project.path_with_namespace}, to: {duo_features_enabled}: {e.errors[0]["message"]}"
+                f"Failed to update duo_features_enabled for Project: {project.path_with_namespace}, to: {duo_features_enabled}: {error_message}"
             )

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
-from gitlab import Gitlab
+from gitlab import Gitlab, GraphQL
 from gitlab.v4.objects import Group, Project, User, ProjectAccessToken, GroupAccessToken
 
 from gitlabform.gitlab import AccessLevel, GitLab
@@ -36,6 +36,11 @@ def message_recorder():
 @pytest.fixture(scope="session")
 def gl():
     return Gitlab(os.getenv("GITLAB_URL"), private_token=os.getenv("GITLAB_TOKEN"))
+
+
+@pytest.fixture(scope="session")
+def gl_graphql():
+    return GraphQL(url=os.getenv("GITLAB_URL"), token=os.getenv("GITLAB_TOKEN"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/acceptance/premium/test_group_settings.py
+++ b/tests/acceptance/premium/test_group_settings.py
@@ -1,13 +1,12 @@
 import pytest
 
 from tests.acceptance import run_gitlabform
-from gitlabform.gitlab import AccessLevel
 
 pytestmark = pytest.mark.requires_license
 
 
 class TestGroupSettings:
-    def test__edit_new_setting_premium(self, gl, project, group):
+    def test__can_set_file_template_project_id(self, gl, project, group):
         assert "file_template_project_id" not in group.attributes
 
         edit_group_settings = f"""

--- a/tests/acceptance/ultimate/test_group_settings.py
+++ b/tests/acceptance/ultimate/test_group_settings.py
@@ -1,0 +1,44 @@
+import pytest
+
+from tests.acceptance import run_gitlabform
+
+pytestmark = pytest.mark.requires_license
+
+
+class TestGroupSettings:
+    def test__can_set_gitlab_duo_flags(self, gl, project, group, subgroup, other_subgroup):
+        instance_settings = gl.settings.get()
+        instance_settings.duo_features_enabled = True
+        instance_settings.save()
+
+        edit_group_settings = f"""
+        projects_and_groups:
+          {group.full_path}/*:
+            group_settings:
+              duo_availability: default_off
+          {subgroup.full_path}/*:
+            group_settings:
+              duo_features_enabled: true
+          {other_subgroup.full_path}/*:
+            group_settings:
+              lfs_enabled: true
+        """
+
+        run_gitlabform(edit_group_settings, group)
+
+        refreshed_group = gl.groups.get(group.id)
+        assert refreshed_group.duo_features_enabled is False
+        # Despite: https://docs.gitlab.com/api/groups/#get-a-single-group stating duo_availability is returned by the API
+        # it is not... https://gitlab.com/gitlab-org/gitlab/-/issues/572223
+        # assert refreshed_group.duo_availability is "default_off"
+
+        refreshed_subgroup = gl.groups.get(subgroup.id)
+        assert refreshed_subgroup.duo_features_enabled is True
+
+        refreshed_other_subgroup = gl.groups.get(other_subgroup.id)
+        # parent group setting has duo_availability as "default_off" so shouldn't be enabled since not explicitly set
+        assert refreshed_other_subgroup.duo_features_enabled is False
+
+        instance_settings = gl.settings.get()
+        instance_settings.duo_features_enabled = False
+        instance_settings.save()

--- a/tests/acceptance/ultimate/test_project_settings.py
+++ b/tests/acceptance/ultimate/test_project_settings.py
@@ -1,0 +1,64 @@
+import pytest
+from gitlab import Gitlab, GraphQL
+from gitlab.v4.objects import Project, Group
+
+from tests.acceptance import run_gitlabform
+
+pytestmark = pytest.mark.requires_license
+
+
+class TestProjectSettings:
+    def test__can_set_duo_features_enabled(
+        self, gl: Gitlab, gl_graphql: GraphQL, group: Group, project: Project, other_project: Project
+    ) -> None:
+        instance_settings = gl.settings.get()
+        instance_settings.duo_features_enabled = True
+        instance_settings.lock_duo_features_enabled = False
+        instance_settings.save()
+
+        # Set up the parent Group to have Duo features enabled but by default set to off for sub-groups and projects
+        group.duo_features_enabled = True
+        group.duo_availability = "default_off"
+        group.save()
+
+        config_builds_for_private_projects: str = f"""
+        projects_and_groups:
+          {project.path_with_namespace}:
+            project_settings:
+                duo_features_enabled: true
+          {other_project.path_with_namespace}:
+            project_settings:
+                duo_features_enabled: false
+        """
+
+        run_gitlabform(config_builds_for_private_projects, project)
+        assert self.project_duo_features_enabled(gl_graphql, project.path_with_namespace) is True
+
+        run_gitlabform(config_builds_for_private_projects, other_project)
+        assert self.project_duo_features_enabled(gl_graphql, other_project.path_with_namespace) is False
+
+        instance_settings = gl.settings.get()
+        instance_settings.duo_features_enabled = False
+        instance_settings.save()
+
+    @staticmethod
+    def project_duo_features_enabled(gl_graphql: GraphQL, project_path: str) -> bool:
+        """
+        Queries GraphQL to get the Project's duo features enabled state, as this is not available via the REST API.
+        """
+
+        query = (
+            """
+            {
+              project(fullPath: \""""
+            + project_path
+            + """\") 
+              {
+                   duoFeaturesEnabled
+              }
+            }
+            """
+        )
+        graphql_response = gl_graphql.execute(query)
+        assert graphql_response["project"] is not None
+        return graphql_response["project"]["duoFeaturesEnabled"]


### PR DESCRIPTION
For Groups: the REST api just works
For Projects: Gitlab only supply the option to toggle via their GraphQL api - so that is implemented via python-gitlab