### PR TITLE
fix: prevent KeyError when using --output with application settings

### DIFF
--- a/gitlabform/output.py
+++ b/gitlabform/output.py
@@ -32,6 +32,7 @@ class EffectiveConfigurationFile:
     def add_configuration(self, project_or_group: str, configuration_name: str, configuration: dict):
         if self.output_file:
             info(f"Adding effective configuration for {configuration_name}.")
+            self.config.setdefault(project_or_group, {})
             self.config[project_or_group][configuration_name] = configuration
 
     def write_to_file(self):

--- a/gitlabform/output.py
+++ b/gitlabform/output.py
@@ -25,15 +25,15 @@ class EffectiveConfigurationFile:
 
         self.config = {}
 
-    def add_placeholder(self, project_or_group: str):
+    def add_placeholder(self, config_key: str):
         if self.output_file:
-            self.config[project_or_group] = {}
+            self.config[config_key] = {}
 
-    def add_configuration(self, project_or_group: str, configuration_name: str, configuration: dict):
+    def add_configuration(self, config_key: str, configuration_name: str, configuration: dict):
         if self.output_file:
             info(f"Adding effective configuration for {configuration_name}.")
-            self.config.setdefault(project_or_group, {})
-            self.config[project_or_group][configuration_name] = configuration
+            self.config.setdefault(config_key, {})
+            self.config[config_key][configuration_name] = configuration
 
     def write_to_file(self):
         if self.output_file:

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,0 +1,19 @@
+from gitlabform.output import EffectiveConfigurationFile
+
+
+def test_no_output_file_is_noop():
+    # when no output file is set, all methods are no-ops
+    effective_configuration = EffectiveConfigurationFile(None)
+    effective_configuration.add_configuration("", "settings", {"admin_mode": True})
+    assert effective_configuration.config == {}
+
+
+def test_add_configuration_without_placeholder(tmp_path):
+    # the "application" section is processed with an empty string key and without a
+    # preceding add_placeholder() call, so add_configuration must create the container
+    output_file = tmp_path / "output.yaml"
+    effective_configuration = EffectiveConfigurationFile(str(output_file))
+
+    effective_configuration.add_configuration("", "settings", {"admin_mode": True})
+
+    assert effective_configuration.config == {"": {"settings": {"admin_mode": True}}}


### PR DESCRIPTION
The application section is processed with an empty string key but without a preceding add_placeholder() call, so writing the effective configuration raised KeyError: ''. Make add_configuration create the container if missing.

Fixes #1383