### PR TITLE
docs: use renamed secret_push_protection_enabled setting

### DIFF
--- a/docs/reference/project_security_settings.md
+++ b/docs/reference/project_security_settings.md
@@ -11,12 +11,6 @@ protection](https://docs.gitlab.com/ee/user/application_security/secret_detectio
 
 Values are documented at the [Project security settings API docs](https://docs.gitlab.com/api/project_security_settings/#update-the-secret_push_protection_enabled-setting).
 
-!!! note
-
-    This setting was renamed from `pre_receive_secret_detection_enabled` to `secret_push_protection_enabled` in GitLab 17.11.
-    Use the new name `secret_push_protection_enabled`. Configs still using the old name will trigger a redundant
-    update on every run, because the GitLab API only reports the setting under its new name.
-
 ## Example
 
 ```yaml

--- a/docs/reference/project_security_settings.md
+++ b/docs/reference/project_security_settings.md
@@ -9,7 +9,13 @@ This section purpose is to manage project security settings, especially [secret 
 On Gitlab Dedicated and Self-managed instances, you must [allow secret push
 protection](https://docs.gitlab.com/ee/user/application_security/secret_detection/secret_push_protection/#allow-the-use-of-secret-push-protection-in-your-gitlab-instance) before you can enable it in a project
 
-Values are documented at [LDAP Group Links section of the Groups API docs](https://docs.gitlab.com/ee/api/project_security_settings.html#update-pre_receive_secret_detection_enabled-setting).
+Values are documented at the [Project security settings API docs](https://docs.gitlab.com/api/project_security_settings/#update-the-secret_push_protection_enabled-setting).
+
+!!! note
+
+    This setting was renamed from `pre_receive_secret_detection_enabled` to `secret_push_protection_enabled` in GitLab 17.11.
+    Use the new name `secret_push_protection_enabled`. Configs still using the old name will trigger a redundant
+    update on every run, because the GitLab API only reports the setting under its new name.
 
 ## Example
 
@@ -17,5 +23,5 @@ Values are documented at [LDAP Group Links section of the Groups API docs](https
 projects_and_groups:
   group_1/project_1:
     project_security_settings:
-      pre_receive_secret_detection_enabled: true
+      secret_push_protection_enabled: true
 ```


### PR DESCRIPTION
The `pre_receive_secret_detection_enabled` setting was renamed to `secret_push_protection_enabled` in GitLab 17.11. Update the example and document that configs using the old name trigger a redundant update on every run, since the API only reports the new name.

Also fix a broken API reference link that pointed to an LDAP anchor.

Fixes #1394