### PR TITLE
build(dev): replace gitlabform development toolkit shortcuts with one entrypoint

### DIFF
--- a/.github/workflows/_releases.yml
+++ b/.github/workflows/_releases.yml
@@ -62,7 +62,7 @@ jobs:
           # Manual Trigger Inputs (from workflow_dispatch)
           MANUAL_RELEASE_TAG: ${{ inputs.manual_tag }}
           MANUAL_UPSTREAM_RUN_ID: ${{ inputs.override_run_id }}
-        run: uv run release gh-workflow-check
+        run: uv run glf-dev release gh-workflow-check
 
   publish-docs:
     name: Publish Docs
@@ -137,7 +137,7 @@ jobs:
           path: dist
       - name: Publish to PyPI
         run: |
-          uv run --no-sync release pypi
+          uv run --no-sync glf-dev release pypi
 
   publish-to-ghcr:
     name: Publish GHCR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
         run: uv sync --frozen --no-dev --group release
       - name: Build and verify the package
         run: |
-          uv run --no-sync package build
-          uv run --no-sync package verify
+          uv run --no-sync glf-dev package build
+          uv run --no-sync glf-dev package verify
       - name: Upload package distribution
         uses: actions/upload-artifact@v7
         with:
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --no-dev --group docs
       - name: Build documentation
-        run: uv run --no-sync docs build
+        run: uv run --no-sync glf-dev docs build
       - name: Upload docs site
         uses: actions/upload-artifact@v7
         with:
@@ -81,4 +81,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --no-dev --group test
       - name: Run smoke tests
-        run: uv run --no-sync gitlabform -V
+        run: uv run --no-sync glf-dev gitlabform -V

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,4 +81,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --no-dev --group test
       - name: Run smoke tests
-        run: uv run --no-sync glf-dev gitlabform -V
+        run: uv run --no-sync gitlabform -V

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Run ${{ matrix.check }}
         run: |
           if [ "${{ matrix.check }}" == "black" ]; then
-            uv run --no-sync qa lint black --check .
+            uv run --no-sync glf-dev qa lint black --check .
           elif [ "${{ matrix.check }}" == "mypy" ]; then
-            uv run --no-sync qa lint mypy .
+            uv run --no-sync glf-dev qa lint mypy .
           elif [ "${{ matrix.check }}" == "bandit" ]; then
-            uv run --no-sync qa lint bandit .
+            uv run --no-sync glf-dev qa lint bandit .
           fi

--- a/.github/workflows/tests-acceptance.yml
+++ b/.github/workflows/tests-acceptance.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --no-dev --group test
       - name: Start GitLab (${{ matrix.flavor }}) in docker
-        run: uv run --no-sync gitlab-local up --gitlab-flavor ${{ matrix.flavor }}
+        run: uv run --no-sync glf-dev gitlab-local up --gitlab-flavor ${{ matrix.flavor }}
       - name: Run Standard acceptance tests for ${{ matrix.flavor }} flavor
-        run: uv run --no-sync qa test tests/acceptance/standard --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 --log-cli-level=WARNING
+        run: uv run --no-sync glf-dev qa test tests/acceptance/standard --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 --log-cli-level=WARNING
       - name: Save PR metadata
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -80,9 +80,9 @@ jobs:
       - name: Start GitLab (${{ matrix.tier }}) in docker
         env:
           GITLAB_EE_LICENSE: "${{ matrix.tier == 'premium' && secrets.GITLAB_EE_LICENSE || secrets.GITLAB_EE_ULTIMATE_LICENSE }}"
-        run: uv run --no-sync gitlab-local up
+        run: uv run --no-sync glf-dev gitlab-local up
       - name: Run acceptance Tests for ${{ matrix.tier }} features
-        run: uv run --no-sync qa test tests/acceptance/${{ matrix.tier }} --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 --log-cli-level=WARNING
+        run: uv run --no-sync glf-dev qa test tests/acceptance/${{ matrix.tier }} --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 --log-cli-level=WARNING
       - name: Save PR metadata
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --no-dev --group test
       - name: Run unit tests
-        run: uv run --no-sync qa test tests/unit --cov=. --cov-report=xml --log-cli-level=WARNING
+        run: uv run --no-sync glf-dev qa test tests/unit --cov=. --cov-report=xml --log-cli-level=WARNING
       - name: Save PR metadata
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/dev/gitlab/run_gitlab_in_docker.sh
+++ b/dev/gitlab/run_gitlab_in_docker.sh
@@ -219,7 +219,7 @@ echo ''
 
 # Provide instructions for stopping and starting GitLab
 cecho b 'To stop and delete the GitLab container, run:'
-cecho y 'uv run gitlab-local down'
+cecho y 'uv run glf-dev gitlab-local down'
 echo ''
 cecho b 'Alternatively to do it manually, you can run:'
 cecho r "docker stop --time=30 gitlab"
@@ -232,5 +232,5 @@ cecho b '(This is the only way to make GitLab in Docker stable.)'
 echo ''
 
 cecho b 'To start the acceptance tests, run:'
-cecho y 'uv run qa test tests/acceptance'
+cecho y 'uv run glf-dev qa test tests/acceptance'
 echo ''

--- a/dev/main.py
+++ b/dev/main.py
@@ -7,7 +7,22 @@ import sys
 from pathlib import Path
 
 # Add the project root to sys.path to allow running this script directly
-sys.path.append(str(Path(__file__).resolve().parent.parent))
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(REPO_ROOT))
+
+
+def _ensure_repo_context() -> None:
+    """Fail fast unless the command is being run from inside the gitlabform repo."""
+    cwd = Path.cwd().resolve()
+    repo_root = REPO_ROOT.resolve()
+    if cwd == repo_root or repo_root in cwd.parents:
+        return
+
+    print("glf-dev: this command must be run from inside the gitlabform repository.", file=sys.stderr)
+    print(f"Current directory: {cwd}", file=sys.stderr)
+    print(f"Expected repo root: {repo_root}", file=sys.stderr)
+    raise SystemExit(2)
+
 
 from dev.docs import docs_build, docs_serve
 from dev.env import clean as run_clean_logic, setup as run_setup_logic
@@ -307,6 +322,7 @@ def gitlab_local():
 
 def main():
     """Main entry point for direct script execution."""
+    _ensure_repo_context()
     parser = argparse.ArgumentParser(description="GitLabForm Development Toolkit")
     subparsers = parser.add_subparsers(dest="domain", help="Task domains")
 

--- a/dev/main.py
+++ b/dev/main.py
@@ -2,13 +2,9 @@
 """Central entry point and CLI facade for the GitLabForm development toolkit."""
 
 import argparse
-import os
 import sys
 from pathlib import Path
-
-# Add the project root to sys.path to allow running this script directly
-REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.append(str(REPO_ROOT))
+from dev.common import REPO_ROOT
 
 
 def _ensure_repo_context() -> None:
@@ -261,65 +257,6 @@ def _dispatch_qa(args):
         run_test_logic(args.extra_args)
 
 
-# --- Domain Shortcut Entry Points ---
-
-
-def _domain_entrypoint(prog, description, setup_fn, dispatch_fn):
-    """Generic helper for domain-specific entry points."""
-    parser = argparse.ArgumentParser(prog=prog, description=description)
-    setup_fn(parser.add_subparsers(dest="command"))
-    args, extra = parser.parse_known_args()
-
-    # Combine unknown arguments (like flags) with the 'extra_args' list if it exists.
-    # This allows passthrough commands like 'up' to receive flags like --help.
-    if hasattr(args, "extra_args") and extra:
-        if args.extra_args is None:
-            args.extra_args = extra
-        else:
-            args.extra_args = extra + args.extra_args
-
-    if not args.command:
-        parser.print_help()
-        sys.exit(0)
-
-    dispatch_fn(args)
-
-
-def workspace():
-    """Shortcut for 'uv run workspace'."""
-    _domain_entrypoint("workspace", DESC_WORKSPACE, _add_workspace_subcommands, _dispatch_workspace)
-
-
-def qa():
-    """Shortcut for 'uv run qa'."""
-    _domain_entrypoint("qa", DESC_QA, _add_qa_subcommands, _dispatch_qa)
-
-
-def docs():
-    """Shortcut for 'uv run docs'."""
-    _domain_entrypoint("docs", DESC_DOCS, _add_docs_subcommands, _dispatch_docs)
-
-
-def package():
-    """Shortcut for 'uv run package'."""
-    _domain_entrypoint("package", DESC_PACKAGE, _add_package_subcommands, _dispatch_package)
-
-
-def docker():
-    """Shortcut for 'uv run docker'."""
-    _domain_entrypoint("docker", DESC_DOCKER, _add_docker_subcommands, _dispatch_docker)
-
-
-def release():
-    """Shortcut for 'uv run release'."""
-    _domain_entrypoint("release", DESC_RELEASE, _add_release_subcommands, _dispatch_release)
-
-
-def gitlab_local():
-    """Shortcut for 'uv run gitlab-local'. Provides orchestration for the local GitLab instance."""
-    _domain_entrypoint("gitlab-local", DESC_INFRA, _add_infra_subcommands, _dispatch_infra)
-
-
 def main():
     """Main entry point for direct script execution."""
     _ensure_repo_context()
@@ -351,7 +288,7 @@ def main():
     args, extra = parser.parse_known_args()
 
     # Combine unknown arguments (flags) with the 'extra_args' list if it exists.
-    # This applies when running via the main 'dev' entrypoint.
+    # This applies when running via the main 'glf-dev' entrypoint.
     if hasattr(args, "extra_args") and extra:
         if args.extra_args is None:
             args.extra_args = extra

--- a/dev/package.py
+++ b/dev/package.py
@@ -29,7 +29,7 @@ def python_verify(extra_args: list[str] | None = None):
     # 1. Ensure build artifacts exist
     if not dist_path.exists() or not any(dist_path.iterdir()):
         logger.error(f"[bold red]❌ Build directory '{dist_path}/' is missing or empty.[/bold red]")
-        logger.info("Hint: Run [bold cyan]uv run package build[/bold cyan] first.")
+        logger.info("Hint: Run [bold cyan]uv run glf-dev package build[/bold cyan] first.")
         sys.exit(1)
 
     wheels = [str(p) for p in dist_path.glob("*.whl")]

--- a/dev/release.py
+++ b/dev/release.py
@@ -143,11 +143,11 @@ def gh_workflow_check(extra_args: list[str] | None = None):
 
     LOCAL TESTING:
     1. Manual Trigger:
-       GH_TOKEN="your_pat" EVENT="workflow_dispatch" REPO="owner/repo" MANUAL_RELEASE_TAG="v1.0.0" MANUAL_UPSTREAM_RUN_ID="12345" uv run release gh-workflow-check
+       GH_TOKEN="your_pat" EVENT="workflow_dispatch" REPO="owner/repo" MANUAL_RELEASE_TAG="v1.0.0" MANUAL_UPSTREAM_RUN_ID="12345" uv run glf-dev release gh-workflow-check
 
     2. Automated Trigger:
        GH_TOKEN="your_pat" EVENT="workflow_run" REPO="owner/repo" CONCLUSION="success" \
-       SHA="$(git rev-parse HEAD)" AUTOMATED_UPSTREAM_RUN_ID="67890" uv run release gh-workflow-check
+       SHA="$(git rev-parse HEAD)" AUTOMATED_UPSTREAM_RUN_ID="67890" uv run glf-dev release gh-workflow-check
     """
     event_name = os.environ.get("EVENT")
     repo = os.environ.get("REPO")

--- a/docs/contrib/local_development.md
+++ b/docs/contrib/local_development.md
@@ -1,6 +1,6 @@
 # Local Development
 
-Welcome to the GitLabForm development guide. We use **`uv`** and a unified development toolkit to manage our lifecycle, ensuring a fast, deterministic, and reproducible environment for all contributors.
+Welcome to the GitLabForm development guide. We use **`uv`** and a repo-scoped development toolkit to manage the project lifecycle in a fast, deterministic, and reproducible way.
 
 ## Required tools
 
@@ -15,48 +15,40 @@ Following tools are used in this project. Please make sure you have them install
 The project provides a comprehensive CLI (**the development toolkit**) organized into task domains. You can discover the available domains by running the main entry point:
 
 ```bash
-uv run dev --help
+uv run glf-dev --help
 ```
 
-### Command Shortcuts
+### Command style
 
-While `dev` is the central entry point, each domain is also registered as a direct shortcut in your environment. You can omit the `dev` prefix from any command for a more concise experience. For example, these two commands are identical:
+Use `glf-dev` for all developer commands, for example:
 
-* Full: `uv run dev workspace setup`
-* Shortcut: `uv run workspace setup`
-
-Each domain (like qa, docs, or workspace) provides its own help context. If you are ever unsure of the available sub-commands or arguments, simply run the domain name or add the `--help` flag:
-
-```bash
-uv run workspace            # Shows help for workspace setup and cleanup
-uv run workspace --help     # Same as above
-uv run docker build --help  # Shows help and available flags for Docker builds
-```
+* `uv run glf-dev workspace setup`
+* `uv run glf-dev qa lint`
+* `uv run glf-dev docker build --help`
 
 A standard lifecycle for implementing a new feature or bug fix typically involves:
 
 1. **New branch**: Create a new branch for your changes.
-2. **Setup**: Initialize or update your local workspace using uv run workspace setup. This also installs the Git hooks. See Workspace Management section for more details. See [Workspace management](#workspace-management) section for more details.
+2. **Setup**: Initialize or update your local workspace using `uv run glf-dev workspace setup`. This also installs the Git hooks. See [Workspace management](#workspace-management) for more details.
 3. **Develop**: Implement your logic or fix in the codebase.
-4. **Quality**: Format and lint your code via the qa domain. See [Code quality](#code-quality) section for more details.
-5. **Test**: Be sure to include/update tests for your changes. See [Testing](#testing) section for more details.
-6. **Validate**: Perform a final check on the build artifacts. See [Building & Verification](#building-verification) section for more details.
+4. **Quality**: Format and lint your code via the `qa` domain. See [Code quality](#code-quality) for more details.
+5. **Test**: Be sure to include/update tests for your changes. See [Testing](#testing) for more details.
+6. **Validate**: Perform a final check on the build artifacts. See [Building & Verification](#building-verification) for more details.
 7. **Commit**: Record your changes using the **Conventional Commits** standard. The Git hooks installed during setup will automatically validate your commit messages.
 
     !!! tip "Guided experience via Commitizen"
 
-        You can use `uv run cz commit` that will present an interactive option in the terminal for selecting and commiting your changes.
+        You can use `uv run cz commit` that will present an interactive option in the terminal for selecting and committing your changes.
 
-8. **Documentation**: Add/update documentation if necessary for the change being introduced. See [Documentation](#documentation) section for more details.
+8. **Documentation**: Add/update documentation if necessary for the change being introduced. See [Documentation](#documentation) for more details.
 9. **Open/Update PR**: Push your changes to GitHub and create/update a pull request.
-
 
 ## Workspace Management
 
-Managing your development environment is handled by the workspace domain. We use `uv` to provide a consistent, isolated, and reproducible environment where everything is contained within an automatically managed `.venv`.
+Managing your development environment is handled by the `workspace` domain. We use `uv` to provide a consistent, isolated, and reproducible environment where everything is contained within an automatically managed `.venv`.
 
 ```bash
-uv run workspace setup
+uv run glf-dev workspace setup
 ```
 
 This command performs several automated tasks:
@@ -69,7 +61,7 @@ This command performs several automated tasks:
 To reset your workspace and remove all build artifacts, caches, and the virtual environment:
 
 ```bash
-uv run workspace clean
+uv run glf-dev workspace clean
 ```
 
 ## Code Quality
@@ -81,7 +73,7 @@ Maintaining high code quality is essential for the stability and readability of 
 We use **black** to enforce a consistent code style across the entire repository. This ensures that the codebase remains readable and reduces friction during code reviews.
 
 ```bash
-uv run qa format
+uv run glf-dev qa format
 ```
 
 ### Linting
@@ -89,19 +81,19 @@ uv run qa format
 We use several tools (including `mypy` for type checking and `bandit` for security auditing) to catch potential issues before they are committed. By default, the `lint` command runs all configured checks in parallel.
 
 ```bash
-uv run qa lint
+uv run glf-dev qa lint
 ```
 
 You can also run a specific tool or pass additional arguments directly to the underlying linter. For example, to run only mypy with specific flags:
 
 ```bash
-uv run qa lint mypy .
+uv run glf-dev qa lint mypy .
 ```
 
 To see the list of available linting tools and help:
 
 ```bash
-uv run qa lint --help
+uv run glf-dev qa lint --help
 ```
 
 ## Testing
@@ -111,23 +103,23 @@ We use **pytest** as the underlying engine for our entire test suite. The toolki
 To discover all available testing options for the `qa` domain:
 
 ```bash
-uv run qa test --help
+uv run glf-dev qa test --help
 ```
 
 **Common examples:**
 
-- Run tests matching a keyword: `uv run qa test -k "archive"`
-- Run tests with verbose output: `uv run qa test -v`
-- Run with coverage reporting: `uv run qa test --cov=.`
-- Run a specific test file/suite: `uv run qa test tests/<path-to-test-file>`
-- Run a specific test within a test file/suite: `uv run qa test tests/<path-to-test-file>::<test-class>::<test-method>`
+- Run tests matching a keyword: `uv run glf-dev qa test -k "archive"`
+- Run tests with verbose output: `uv run glf-dev qa test -v`
+- Run with coverage reporting: `uv run glf-dev qa test --cov=.`
+- Run a specific test file/suite: `uv run glf-dev qa test tests/<path-to-test-file>`
+- Run a specific test within a test file/suite: `uv run glf-dev qa test tests/<path-to-test-file>::<test-class>::<test-method>`
 
 ### Unit Tests
 
 Unit tests are fast, isolated, and do not require a running GitLab instance. They are ideal for validating logic and configuration parsing:
 
 ```bash
-uv run qa test tests/unit
+uv run glf-dev qa test tests/unit
 ```
 
 ### Acceptance Tests
@@ -139,47 +131,45 @@ Acceptance tests perform real operations against a running GitLab instance. Beca
     We recommend running tests against a disposable GitLab instance in Docker to ensure your environment matches our CI/CD pipelines:
 
     ```bash
-    uv run gitlab-local up # Starts Enterprise Edition (EE) by default
-    uv run gitlab-local down # Cleanup: Stops and removes the local GitLab container
+    uv run glf-dev gitlab-local up # Starts Enterprise Edition (EE) by default
+    uv run glf-dev gitlab-local down # Cleanup: Stops and removes the local GitLab container
     ```
 
     !!! note
-    
-        Use `uv run gitlab-local up --gitlab-flavor ce` to test against Community Edition.
+
+        Use `uv run glf-dev gitlab-local up --gitlab-flavor ce` to test against Community Edition.
 
     To see all available infrastructure management options:
 
     ```bash
-    uv run gitlab-local up --help
+    uv run glf-dev gitlab-local up --help
     ```
-    
+
     !!! tip "Testing against specific versions"
-        You can test against specific GitLab releases using the version flag: `uv run gitlab-local up --gitlab-version 17.5.0-ee`.
+        You can test against specific GitLab releases using the version flag: `uv run glf-dev gitlab-local up --gitlab-version 17.5.0-ee`.
 
     !!! note "Testing paid features"
-    
-        To test features requiring a GitLab instance with **Premium** or **Ultimate** tier, you'll need to have a license from GitLab that can be used for enabling those features in your local GitLab instance.
-        
-        Once you've obtained your license, you can set the `GITLAB_EE_LICENSE` environment variable or place your license in a file named `Gitlab.gitlab-license` in the project root. Our dev toolkit will automatically detect and apply this license during the setup. This file is also included in `.gitignore` so that it's not committed to the repository.
 
+        To test features requiring a GitLab instance with **Premium** or **Ultimate** tier, you'll need to have a license from GitLab that can be used for enabling those features in your local GitLab instance.
+
+        Once you've obtained your license, you can set the `GITLAB_EE_LICENSE` environment variable or place your license in a file named `Gitlab.gitlab-license` in the project root. Our dev toolkit will automatically detect and apply this license during the setup. This file is also included in `.gitignore` so that it's not committed to the repository.
 
 2. Run the tests
 
-    Once the GitLab instance is healthy and accessible, execute the acceptance located in `tests/acceptance/` directory. See the examples above on how to run the tests.
+    Once the GitLab instance is healthy and accessible, execute the acceptance tests located in the `tests/acceptance/` directory. See the examples above on how to run the tests.
 
     !!! tip
 
-        Acceptance tests are usually slower than unit tests since they run against a real GitLab instance. This involves creating, updating, and deleting resources in GitLab. You may find it helpful to run only select tests instead of entire test suite. For example: run all tests related to the feature you're working on.
-
+        Acceptance tests are usually slower than unit tests since they run against a real GitLab instance. This involves creating, updating, and deleting resources in GitLab. You may find it helpful to run only select tests instead of the entire suite. For example: run all tests related to the feature you're working on.
 
 ### Using a Remote GitLab Instance
 
-It's not recommended, but if you prefer to run tests against non-local/disposable GitLab instance, provide the credentials via environment variables:
+It's not recommended, but if you prefer to run tests against a non-local/disposable GitLab instance, provide the credentials via environment variables:
 
 ```bash
 export GITLAB_URL="https://mygitlab.company.com"
 export GITLAB_TOKEN="<admin_api_token>"
-uv run qa test tests/acceptance
+uv run glf-dev qa test tests/acceptance
 ```
 
 ## Building & Verification
@@ -191,62 +181,61 @@ This section covers creating the distributable artifacts for the project, includ
 We generate standard Python distribution artifacts (source distribution and wheels) that can be uploaded to PyPI. To generate the artifacts in the `dist/` directory:
 
 ```bash
-uv run package build
+uv run glf-dev package build
 ```
 
 To see available build options:
 
 ```bash
-uv run package build --help
+uv run glf-dev package build --help
 ```
 
 The `package verify` command performs an audit of the built files to ensure they are ready for release. This includes metadata validation via `twine`, content auditing via `check-wheel-contents`, and an automated smoke test that installs the wheel in a temporary isolated environment to check the entry point.
 
 ```bash
-uv run package verify
+uv run glf-dev package verify
 ```
-
 
 ### Docker Images
 
 The Docker image is the recommended way to run GitLabForm in CI/CD environments. To build the image locally using our multi-stage `Dockerfile`:
 
 ```bash
-uv run docker build
+uv run glf-dev docker build
 ```
 
 You can customize the image name and tag via arguments:
 
 ```bash
-uv run docker build --image my-registry/gitlabform --tag dev
+uv run glf-dev docker build --image my-registry/gitlabform --tag dev
 ```
 
 To see all Docker build options:
 
 ```bash
-uv run docker build --help
+uv run glf-dev docker build --help
 ```
 
 To ensure the newly built image is functional, run a smoke test that executes the application version check inside a container:
 
 ```bash
-uv run docker verify
+uv run glf-dev docker verify
 ```
 
 To see options for Docker verification:
 
 ```bash
-uv run docker verify --help
+uv run glf-dev docker verify --help
 ```
 
 ## Documentation
 
-We use **Zensical** to generate our project documentation. The toolkit provides commands via the `docs` domain to preview changes locally and build the final static site.
+We use **Zensical** to generate our project documentation. The toolkit provides commands through the `docs` domain to preview changes locally and build the final static site.
 
-To serve the documentation with live-reloading (ideal for seeing your changes in real-time as you edit the markdown files):
+To serve the documentation with live-reloading (ideal for seeing your changes in real time as you edit the markdown files):
 
 ```bash
-uv run docs serve
+uv run glf-dev docs serve
 ```
 
 The site will be available at `http://localhost:8000`.
@@ -254,11 +243,11 @@ The site will be available at `http://localhost:8000`.
 To generate the static documentation site in the `site/` directory (used for deployment to GitHub Pages):
 
 ```bash
-uv run docs build
+uv run glf-dev docs build
 ```
 
 To see all documentation management options:
 
 ```bash
-uv run docs --help
+uv run glf-dev docs --help
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,23 +103,9 @@ content-type = "text/markdown"
 # Primary application entrypoint
 gitlabform = "gitlabform.run:run"
 
-# Development toolkit and environment management
-dev = "dev.main:main"
-workspace = "dev.main:workspace"
-
-# Development workflow (Linting, Formatting, and Testing)
-qa = "dev.main:qa"
-
-# Local infrastructure management
-gitlab-local = "dev.main:gitlab_local"
-
-# Documentation workflow
-docs = "dev.main:docs"
-
-# Packaging and distribution verification
-package = "dev.main:package"
-docker = "dev.main:docker"
-release = "dev.main:release"
+# GitlabForm development toolkit: only works when invoked from inside the
+# gitlabform repository itself.
+glf-dev = "dev.main:main"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]


### PR DESCRIPTION
Currently we have a separate package that's used as a development toolkit. This is intended for development of gitlabform itself. The toolkit (cli) gives domain based options for various tasks such as: buiding and verifying python package, running linters, starting up a local gitalb instance, running tests, etc. Almost all of these commands are also used in the CI process. This keeps dev and CI process in sync.

When this toolkit was setup, they were added in `pyproject.toml` under the `[project.scripts]` configuration section. I found recently that this results in an expected behaviour. Each items becomes installed globally. For example: within the gitlabform repo, we can run `uv run dev -h`, but it also possible to run `dev -h` from anywhere, even outside the repository.

Each of the items from the dev toolkit that were added there was inteded as a shortcut. For example: instead of running `uv run dev workspace setup`, we can run `uv run workspace setup`. Because these are installed/available globally, it has a bigger consequence when there are naming collision. For example, the toolkit provides command `uv run dev docker build` or `uv run docker build`. Since the `docker` command from this toolkit becomes available globally, it collides with standard docker-cli.

This PR fixes the above issue in following ways:

- Rename the dev toolkit's entrypoint from `dev` to `glf-dev`. This way it's clear what this is referring to while keeping the name short for convenience.
- Removed all the shortcut entrypoints that were added before. Now all commands has to go through `glf-dev`. For example: `uv run glf-dev <command> <option>`
- Since `glf-dev` becomes available globally, added a check so that running `glf-dev` outside the gitlabform repo will not run or execute because it won't function as intended outside of the repo anyways.
