### PR TITLE
chore(deps): reduce uv dev dependency update cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,29 +9,35 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "production"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "development"
     groups:
-      # Group dependencies by their type (testing, linting, documentation, release tools)
-      # to avoid overwhelming PRs and to allow for more focused updates.
-      # The patterns are based on the names of the dependencies as they appear in the pyproject.toml file
-      # and how they are grouped in the uv configuration.
-      # Dependencies that match the patterns will be grouped together in the same PR.
-      testing:
+      # Keep the dev-only dependency update churn lower by checking it monthly,
+      # while still keeping the largest dev tool groups focused.
+      dev-tooling:
         patterns:
           - "pytest*"
           - "coverage"
           - "cryptography"
           - "deepdiff"
           - "xkcdpass"
-      linting:
-        patterns:
           - "bandit"
           - "black"
           - "codespell"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,15 +19,28 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    allow:
-      - dependency-type: "production"
-
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-type: "development"
+    cooldown:
+      default-days: 30
+      include:
+        - "pytest*"
+        - "coverage"
+        - "cryptography"
+        - "deepdiff"
+        - "xkcdpass"
+        - "bandit"
+        - "black"
+        - "codespell"
+        - "mypy*"
+        - "ruff"
+        - "types-*"
+        - "markdown*"
+        - "zensical*"
+        - "pygments"
+        - "pymdown-extensions"
+        - "check-wheel-contents"
+        - "twine"
+        - "commitizen"
+        - "prek"
     groups:
       # Keep the dev-only dependency update churn lower by checking it monthly,
       # while still keeping the largest dev tool groups focused.


### PR DESCRIPTION
I feel the weekly PRs opened by dependabot are a bit noisy. Usually they are just patch updates for various dev tools. There's a 5 PR limit and most of the time they are taken up by these dev tools update. Main goal of this PR is to reduce the frequency of dev tools update. Below are the changes that have been made to dependabot config.

- ~~Split uv updates into production and development dependency groups~~
- Keep runtime deps on the normal weekly schedule
- Set dev deps to a monthly schedule to reduce update noise
- Merge overlapping test/lint patterns into a single dev tooling group so that they are combined into a single PR
- Keep documentation and release tooling groups separate

I'm not sure there's an easy and reliable way to validate the config. I tested it in my forked repo and dependabot didn't seem to complain about the config. So, it should be good syntax-wise.
